### PR TITLE
Use a fixed supabase version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
       - name: Install Supabase
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # We would like to use 'latest' here, but that runs into a rate limit of Github.
+          # See https://github.com/supabase/setup-cli/issues/106
+          version: 1.24.0
 
       - name: Start Supabase - Toitware
         shell: bash


### PR DESCRIPTION
This avoids the rate-limit we are sometimes seeing with 'latest'. See https://github.com/supabase/setup-cli/issues/106