### PR TITLE
Create new devices when running tests.

### DIFF
--- a/supabase/src/supabase.toit
+++ b/supabase/src/supabase.toit
@@ -141,15 +141,16 @@ class Client:
   ```
   */
   ensure_authenticated [block]:
-    exception := catch:
-      if local_storage_.has_auth:
+    if local_storage_.has_auth:
+      catch:
         session_ = Session_.from_json local_storage_.get_auth
         // TODO(florian): no need to refresh if the token is still valid.
         auth.refresh_token
-    if exception:
+        return
+      // There was an exception.
       // Clear the stored session, and run the block for a fresh authentication.
       local_storage_.remove_auth
-      block.call auth
+    block.call auth
 
   close -> none:
     // TODO(florian): call close on the http client (when that's possible).

--- a/tests/cmd_auth_test.toit
+++ b/tests/cmd_auth_test.toit
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Toitware ApS.
+
+// TEST_FLAGS: --supabase-server --http-server
+
+import expect show *
+import .utils
+
+main args:
+  if args.is_empty: args = ["--http-server"]
+
+  artemis_type/string := ?
+  if args[0] == "--supabase-server":  artemis_type = "supabase"
+  else if args[0] == "--http-server": artemis_type = "http"
+  else: throw "Unknown artemis type: $args[0]"
+
+  with_test_cli
+      --artemis_type=artemis_type
+      --no-start_device_artemis
+      : | test_cli/TestCli _ |
+        run_test test_cli
+
+run_test test_cli/TestCli:
+  test_start := Time.now
+
+  // Some command that requires to be authenticated.
+  output := test_cli.run --expect_exit_1 [ "org", "list" ]
+  expect (output.contains "Not logged in")
+
+  test_cli.run [
+    "auth", "artemis", "login",
+    "--email", TEST_EXAMPLE_COM_EMAIL,
+    "--password", TEST_EXAMPLE_COM_PASSWORD,
+  ]
+
+  output = test_cli.run [ "org", "list" ]

--- a/tests/cmd_max_offline_test.toit
+++ b/tests/cmd_max_offline_test.toit
@@ -1,10 +1,10 @@
 // Copyright (C) 2022 Toitware ApS.
 
-// TEST_FLAGS: --supabase-server|--http_broker --http-server|--http_broker --supabase-server|--supabase_broker --http-server|--supabase_broker
+// TEST_FLAGS: --supabase-server|--http-broker --http-server|--http-broker --supabase-server|--supabase-broker --http-server|--supabase-broker
 import .utils
 
 main args:
-  if args.is_empty: args = ["--http-server", "--http_broker"]
+  if args.is_empty: args = ["--http-server", "--http-broker"]
 
   artemis_type/string := ?
   if args.contains "--supabase-server":  artemis_type = "supabase"
@@ -12,8 +12,8 @@ main args:
   else: throw "Unknown artemis type: $args[0]"
 
   broker_type/string := ?
-  if args.contains "--supabase_broker":  broker_type = "supabase"
-  else if args.contains "--http_broker": broker_type = "http"
+  if args.contains "--supabase-broker":  broker_type = "supabase"
+  else if args.contains "--http-broker": broker_type = "http"
   else: throw "Unknown broker type: $args[1]"
 
   with_test_cli


### PR DESCRIPTION
Otherwise tests that run in parallel could interfere with each other.