### PR TITLE
Allow devices to report their status without having an entry.

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -216,7 +216,7 @@ class Artemis:
         ui_.abort
 
     if not wifi_connection:
-      ui_.error "No wifi connection configured."
+      ui_.error "No WiFi connection configured."
       ui_.abort
 
     // Create the assets for the Artemis service.
@@ -262,19 +262,15 @@ class Artemis:
 
       sdk.firmware_add_container "artemis" --envelope=output_path
           --assets=artemis_assets_path
-          --image=artemis_service_image_path
+          --app_path=artemis_service_image_path
 
       // Store the apps in the envelope.
       device_specification.apps.do: | name/string app/Application |
         snapshot_app := to_snapshot_app_ app --tmp_dir=tmp_dir --sdk=sdk
-        image_path := "$tmp_dir/$(name).image"
-        // TODO(florian): we should get the bits from the envelope.
-        sdk.compile_snapshot_to_image
-            --bits=32
-            --snapshot_path=snapshot_app.snapshot_path
-            --out=image_path
         // TODO(florian): add support for assets.
-        sdk.firmware_add_container name --envelope=output_path --image=image_path
+        sdk.firmware_add_container name
+            --envelope=output_path
+            --app_path=snapshot_app.snapshot_path
         ui_.info "Added app '$name' to envelope."
 
     sdk.firmware_set_property "wifi-config" (json.stringify wifi_connection)

--- a/src/cli/firmware.toit
+++ b/src/cli/firmware.toit
@@ -154,10 +154,10 @@ class FirmwareContent:
 
   trivial_patches -> List:
     result := []
-    parts.size.repeat: | index/int |
-      part := parts[index]
-      if part is FirmwarePartConfig: continue.repeat
-      result.add (FirmwarePatch --bits=part.bits --to=part.hash)
+    parts.do: | part/FirmwarePart |
+      if part is FirmwarePartConfig: continue.do
+      patch_part := part as FirmwarePartPatch
+      result.add (FirmwarePatch --bits=patch_part.bits --to=patch_part.hash)
     return result
 
 class PatchWriter implements PatchObserver:

--- a/src/cli/sdk.toit
+++ b/src/cli/sdk.toit
@@ -89,9 +89,10 @@ class Sdk:
   /**
   Installs the container $name in the given $envelope.
 
-  The $envelope, the $image and its $assets must be paths to files.
+  The $envelope, the $app_path and its $assets must be paths to files.
+  The parameter $app_path must point to a snapshot or image.
   */
-  firmware_add_container name/string --envelope/string --assets/string?=null --image/string:
+  firmware_add_container name/string --app_path/string --envelope/string --assets/string?=null:
     args := ?
     if assets:
       // TODO(florian): at the moment we can't just add the assets flags to
@@ -101,14 +102,14 @@ class Sdk:
         "-e", envelope,
         "--assets", assets,
         name,
-        image,
+        app_path,
       ]
     else:
       args = [
         "container", "install",
         "-e", envelope,
         name,
-        image,
+        app_path,
       ]
     run_firmware_tool args
 


### PR DESCRIPTION
Don't require an entry in the configs table for devices to report their status.