### PR TITLE
Ignore health check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/supabase_artemis
         run: |
-          supabase start
+          supabase start --ignore-health-check
           supabase status
 
           # Sample output of supabase status:
@@ -121,7 +121,7 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/tests/supabase_customer
         run: |
-          supabase start
+          supabase start --ignore-health-check
           supabase status
 
           API_URL_LINE=$(supabase status | grep "API URL:")
@@ -136,7 +136,7 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/tests/supabase_test
         run: |
-          supabase start
+          supabase start --ignore-health-check
           supabase status
 
       - uses: suisei-cn/actions-download-file@v1.3.0


### PR DESCRIPTION
Sometimes the health-checks for starting supabase aren't succeeding. https://github.com/supabase/cli/issues/778

In many cases the tests still run fine.