### PR TITLE
Merge all customer broker migrations.

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -397,7 +397,6 @@ class Artemis:
 
     identity := ubjson.decode (base64.decode identity_raw)
 
-
     // Since we already have the identity content, check that the artemis server
     // is the same.
     // This is primarily a sanity check, and we might remove the broker from the

--- a/src/service/device.toit
+++ b/src/service/device.toit
@@ -1,7 +1,5 @@
 // Copyright (C) 2022 Toitware ApS. All rights reserved.
 
-import encoding.tison
-
 import ..shared.json_diff show json_equals
 
 /**

--- a/src/service/synchronize.toit
+++ b/src/service/synchronize.toit
@@ -62,7 +62,7 @@ class SynchronizeJob extends Job implements EventHandler:
       // we expect a single 'commit' action for a configuration update.
       while true:
         lambda/Lambda? := null
-        // The timeout is only relevent for the first iteration of the
+        // The timeout is only relevant for the first iteration of the
         // loop, or when max-offline is not set. In all other cases
         // a 'break' will get us out of the loop.
         catch: with_timeout check_in_timeout: lambda = actions_.receive

--- a/src/shared/json_diff.toit
+++ b/src/shared/json_diff.toit
@@ -99,6 +99,7 @@ The comparison is done deeply, and nested objects are compared
   recursively.
 */
 json_equals a/any b/any -> bool:
+  if identical a b: return true
   if a is Map and b is Map:
     if a.size != b.size: return false
     a.do: | key value |
@@ -111,7 +112,7 @@ json_equals a/any b/any -> bool:
       if not json_equals a[i] b[i]: return false
     return true
   else:
-    return identical a b
+    return false
 
 // --------------------------------------------------------------------------
 
@@ -213,7 +214,7 @@ compute_map_modification_ from/Map to/Map [modified] -> UpdatedMap_?:
       if identical from_value to_value:
         continue.do
       else if from_value is List and to_value is List:
-        if list_is_unmodified_ from_value to_value: continue.do
+        if json_equals from_value to_value: continue.do
         modified.call
         modification = Updated_ from_value to_value
       else if from_value is Map and to_value is Map:
@@ -232,25 +233,3 @@ compute_map_modification_ from/Map to/Map [modified] -> UpdatedMap_?:
     modifications = modifications or {:}
     modifications[from_key] = modification
   return modifications ? (UpdatedMap_ from to modifications) : null
-
-map_is_unmodified_ from/Map to/Map -> bool:
-  compute_map_modification_ from to: return false
-  return true
-
-list_is_unmodified_ from/List to/List -> bool:
-  size ::= from.size
-  if to.size != size: return false
-  size.repeat:
-    from_element ::= from[it]
-    to_element ::= to[it]
-    if identical from_element to_element:
-      // No change.
-    else if from_element is List and to_element is List:
-      if not list_is_unmodified_ from_element to_element:
-        return false
-    else if from_element is Map and to_element is Map:
-      if not map_is_unmodified_ from_element to_element:
-        return false
-    else:
-      return false
-  return true


### PR DESCRIPTION
So far we mostly use the migrations locally where it doesn't hurt to change them.
Having one single file makes it easier to change it.