### PR TITLE
Don't notify device of state changes with http broker

### DIFF
--- a/tools/http_servers/broker.toit
+++ b/tools/http_servers/broker.toit
@@ -106,7 +106,6 @@ class HttpBroker extends HttpServer:
   report_state data/Map:
     device_id := data["device_id"]
     device_states[device_id] = data["state"]
-    notify_device device_id "state_updated"
 
   get_state data/Map:
     device_id := data["device_id"]


### PR DESCRIPTION
The state change comes from the device, so there is no need to inform it about the change.