### PR TITLE
Allow multiple signups with the same email.

### DIFF
--- a/tools/http_servers/artemis_server.toit
+++ b/tools/http_servers/artemis_server.toit
@@ -341,7 +341,8 @@ class HttpArtemisServer extends HttpServer:
       throw "Missing email, password"
     users.do: | _ user/User |
       if user.email == email:
-        throw "Email already in use"
+        // We allow users to sign up multiple times with the same email address.
+        return
     user_id := create_user --email=email --name=email
 
   sign_in data/Map:


### PR DESCRIPTION
The HTTP artemis server now allows multiple signups with the same email. This is similar to what supabase does, and makes it easier during development.