### PR TITLE
Run on latest Ubuntu.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # Build on an older Ubuntu, so that we don't depend on a recent glibc.
-        os: [ ubuntu-20.04, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
There is no need to run on older Ubuntu containers. The vessels are created on the Toit buildbot, and as such don't change when changing the GLIBC here.