### PR TITLE
Add a device-id option to the `device` subcommand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # Build on an older Ubuntu, so that we don't depend on a recent glibc.
-        os: [ ubuntu-20.04, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -183,7 +182,7 @@ jobs:
           chmod +x build/bin/artemis
 
       - name: Import signing keychain
-        uses: apple-actions/import-codesign-certs@v1
+        uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/src/cli/device_specification.toit
+++ b/src/cli/device_specification.toit
@@ -162,9 +162,6 @@ class DeviceSpecification:
     sdk_version = get_string_ data "sdk-version"
     artemis_version = get_string_ data "artemis-version"
 
-    if not data.contains "containers" and not data.contains "apps":
-      format_error_ "Missing containers in device specification."
-
     if data.contains "apps" and data.contains "containers":
       format_error_ "Both 'apps' and 'containers' are present in device specification."
 
@@ -176,13 +173,16 @@ class DeviceSpecification:
       data = data.copy
       data["containers"] = data["apps"]
       data.remove "apps"
-    else:
+    else if data.contains "containers":
       check_is_map_ data "containers"
 
-    data["containers"].do --keys:
-      check_is_map_ data["containers"] --entry_type="Container" it
+    containers_entry := data.get "containers"
+    if not containers_entry: containers_entry = {:}
 
-    containers = data["containers"].map: | name container_description |
+    containers_entry.do --keys:
+      check_is_map_ containers_entry --entry_type="Container" it
+
+    containers = containers_entry.map: | name container_description |
           Container.from_json name container_description
 
     connections_entry := get_list_ data "connections"

--- a/tests/parse_device_specification_test.toit
+++ b/tests/parse_device_specification_test.toit
@@ -88,9 +88,8 @@ main:
 
   no_containers := new_valid
   no_containers.remove "containers"
-  expect_format_error
-      "Missing containers in device specification."
-      no_containers
+  // Should work without error.
+  DeviceSpecification.from_json no_containers --path="ignored"
 
   both_apps_and_containers := new_valid
   both_apps_and_containers["apps"] = both_apps_and_containers["containers"]


### PR DESCRIPTION
Instead of having separate device-id options for each device command have one on the 'device' command instead.