### PR TITLE
Add developer configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ TOIT_RUN_BIN?=toit.run
 SETUP_LOCAL_DEV_SDK ?= v2.0.0-alpha.74
 SETUP_LOCAL_DEV_SERVICE ?= v0.0.1
 
+export ARTEMIS_CONFIG := $(HOME)/.config/artemis-dev/config
+
 .PHONY: all
 all: build
 
@@ -37,15 +39,6 @@ ARTEMIS_CERTIFICATE := Baltimore CyberTrust Root
 TOITWARE_TESTING_HOST := ghquchonjtjzuuxfmaub.supabase.co
 TOITWARE_TESTING_ANON := eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdocXVjaG9uanRqenV1eGZtYXViIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NzMzNzQ4ODIsImV4cCI6MTk4ODk1MDg4Mn0.bJB3EdVwFN34yk50JLHv8Pw5IA5gqtEJrXU1MtjEWGc
 TOITWARE_TESTING_CERTIFICATE := Baltimore CyberTrust Root
-
-.PHONY: add-default-brokers
-add-default-brokers: install-pkgs
-	@ # Adds the Toitware supabase Artemis server and makes it the default.
-	@ $(TOIT_RUN_BIN) src/cli/cli.toit config broker add --no-default supabase \
-		--certificate="$(ARTEMIS_CERTIFICATE)" \
-		artemis $(ARTEMIS_HOST) "$(ARTEMIS_ANON)"
-	@ $(TOIT_RUN_BIN) src/cli/cli.toit config broker default --artemis artemis
-	@ $(TOIT_RUN_BIN) src/cli/cli.toit config broker default artemis
 
 .PHONY: start-http
 start-http: install-pkgs

--- a/src/cli/config.toit
+++ b/src/cli/config.toit
@@ -166,14 +166,20 @@ read_config [--init] -> Config:
     return read_config_file env["$(app_name_upper)_CONFIG"] --init=init
 
   config_home := xdg.config_home
+  // Hackish way to improve the developer experience.
+  // When using the toit files to run Artemis, we default to a different
+  // configuration.
+  if program_name.ends_with ".toit":
+    return read_config_file "$config_home/artemis-dev/config" --init=init
+
   // The path we are using to write configurations to.
-  app_config_path := "$(config_home)/$(APP_NAME)/config"
+  app_config_path := "$config_home/$APP_NAME/config"
   if file.is_file app_config_path:
     return read_config_file app_config_path --init=init
 
   // Try to find a configuration file in the XDG config directories.
   xdg.config_dirs.do: | dir |
-    path := "$(dir)/$(APP_NAME)/config"
+    path := "$dir/$APP_NAME/config"
     if file.is_file path:
       from_config_dir := read_config_file path --init=init
       return Config app_config_path from_config_dir.data


### PR DESCRIPTION
When running Artemis with the .toit files use a different configuration. This way it's easier to keep an existing configuration for the real Artemis service.