### PR TITLE
Transition to SYNCHRONIZED state when up-to-date.

### DIFF
--- a/src/service/brokers/http/http.toit
+++ b/src/service/brokers/http/http.toit
@@ -45,8 +45,8 @@ class BrokerConnectionHttp implements BrokerConnection:
         if not wait: return null
         sleep interval - elapsed
     result := connection_.send_request COMMAND_GET_GOAL_ {
-        "_device_id": "$device_.id",
-      }
+      "_device_id": "$device_.id",
+    }
     last_poll_us_ = Time.monotonic_us
     return result
 

--- a/src/service/synchronize.toit
+++ b/src/service/synchronize.toit
@@ -398,6 +398,7 @@ class SynchronizeJob extends TaskJob:
         // No goal state from the broker.
         // Potentially a device that has been flashed and provisioned but hasn't been
         // updated through the broker yet.
+        transition_to_ STATE_SYNCHRONIZED
         return null
       goal = Goal goal_state
 


### PR DESCRIPTION
This now also covers the case where the device hasn't been updated through the broker and thus has a null config stored in the cloud.