### PR TITLE
Fix warning of not having storage for persisting sessions

### DIFF
--- a/supabase_artemis/supabase/functions/README.md
+++ b/supabase_artemis/supabase/functions/README.md
@@ -2,8 +2,22 @@
 
 * Install 'deno'.
 * Install the deno extension.
-* Run the vscode command "Deno: Initialize Workspace Configuration" with this folder as root.
-* In this folder run: `deno cache --import-map=./import_map.json' broker/index.ts` or any other file that needs syntax.
+* Run the vscode command "Deno: Initialize Workspace Configuration" with
+  this folder as root.
+* In this folder run: `deno cache --import-map=./import_map.json' b/index.ts`
+  or any other file that needs syntax.
 
 # Development
-Run
+When starting the supabase containers (`make start-supabase` or
+`make start-supabase-no-config`) the edge functions are automatically started.
+However, local instances don't have any logging enabled.
+
+For development it's thus recommended to call `supabase functions serve`
+(inside this folder).
+
+# Deployment
+To deploy the edge functions, run
+  `supabase functions deplay --no-verify-jwt b`.
+
+(The `--no-verify-jwt` might not be necessary, since the `config.toml` already
+has an entry for the `b` functions. I haven't tested it without it, though.)

--- a/supabase_artemis/supabase/functions/b/index.ts
+++ b/supabase_artemis/supabase/functions/b/index.ts
@@ -51,9 +51,14 @@ function createSupabaseClient(req: Request) {
     Deno.env.get("SUPABASE_URL") ?? "",
     // Supabase API ANON KEY - env var exported by default.
     Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-    // Create client with Auth context of the user that called the function.
-    // This way your row-level-security (RLS) policies are applied.
     {
+      auth: {
+        // Don't try to persist the session. We would get warnings about
+        // no storage option being available.
+        persistSession: false,
+      },
+      // Create client with Auth context of the user that called the function.
+      // This way your row-level-security (RLS) policies are applied.
       global: {
         headers: { Authorization: authorization },
       },

--- a/supabase_broker/supabase/functions/README.md
+++ b/supabase_broker/supabase/functions/README.md
@@ -2,8 +2,22 @@
 
 * Install 'deno'.
 * Install the deno extension.
-* Run the vscode command "Deno: Initialize Workspace Configuration" with this folder as root.
-* In this folder run: `deno cache --import-map=./import_map.json' broker/index.ts` or any other file that needs syntax.
+* Run the vscode command "Deno: Initialize Workspace Configuration" with
+  this folder as root.
+* In this folder run: `deno cache --import-map=./import_map.json' b/index.ts`
+  or any other file that needs syntax.
 
 # Development
-Run
+When starting the supabase containers (`make start-supabase` or
+`make start-supabase-no-config`) the edge functions are automatically started.
+However, local instances don't have any logging enabled.
+
+For development it's thus recommended to call `supabase functions serve`
+(inside this folder).
+
+# Deployment
+To deploy the edge functions, run
+  `supabase functions deplay --no-verify-jwt b`.
+
+(The `--no-verify-jwt` might not be necessary, since the `config.toml` already
+has an entry for the `b` functions. I haven't tested it without it, though.)

--- a/supabase_broker/supabase/functions/b/index.ts
+++ b/supabase_broker/supabase/functions/b/index.ts
@@ -51,9 +51,14 @@ function createSupabaseClient(req: Request) {
     Deno.env.get("SUPABASE_URL") ?? "",
     // Supabase API ANON KEY - env var exported by default.
     Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-    // Create client with Auth context of the user that called the function.
-    // This way your row-level-security (RLS) policies are applied.
     {
+      auth: {
+        // Don't try to persist the session. We would get warnings about
+        // no storage option being available.
+        persistSession: false,
+      },
+      // Create client with Auth context of the user that called the function.
+      // This way your row-level-security (RLS) policies are applied.
       global: {
         headers: { Authorization: authorization },
       },


### PR DESCRIPTION
The logs of our edge functions had lots of warnings:
```
No storage option exists to persist the session, which may result in
  unexpected behavior when using auth.
If you want to set persistSession to true, please provide a storage
  option or you may set persistSession to false to disable this warning.
```

Also updated the README.