### PR TITLE
Add support for container assets

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -257,14 +257,16 @@ class Artemis:
             --cache=cache_
             --ui=ui_
 
-        // Build the assets if any.
+        // Build the assets from the defines (if any).
         assets_path/string? := null
-        if container.assets:
+        if container.defines:
           assets_path = "$tmp_dir/$(name).assets"
-          assets := container.assets.map: | _ value |
-            { "format": "tison",
-              "json": value
+          assets := {
+            "artemis.defines": {
+              "format": "tison",
+              "json": container.defines
             }
+          }
           sdk.assets_create --output_path=assets_path assets
 
         sdk.firmware_add_container name

--- a/src/cli/pod_specification.toit
+++ b/src/cli/pod_specification.toit
@@ -499,7 +499,7 @@ interface Container:
   is_critical -> bool?
   runlevel -> int?
   triggers -> List? // Of type $Trigger.
-  assets -> Map?
+  defines -> Map?
 
   static check_arguments_entry arguments:
     if arguments == null: return
@@ -515,7 +515,7 @@ abstract class ContainerBase implements Container:
   is_background/bool?
   is_critical/bool?
   runlevel/int?
-  assets/Map?
+  defines/Map?
 
   constructor.from_json name/string data/Map:
     holder := "container $name"
@@ -560,7 +560,7 @@ abstract class ContainerBase implements Container:
     else:
       triggers = null
 
-    assets = get_optional_map_ data "assets"
+    defines = get_optional_map_ data "defines"
 
   abstract type -> string
   abstract build_snapshot --output_path/string --relative_to/string --sdk/Sdk --cache/cli.Cache --ui/Ui

--- a/tests/parse_pod_specification_test.toit
+++ b/tests/parse_pod_specification_test.toit
@@ -58,6 +58,13 @@ VALID_SPECIFICATION ::= {
         "boot",
         "install",
       ]
+    },
+    "app5": {
+      "entrypoint": "entrypoint.toit",
+      "defines": {
+        "foo": 17,
+        "bar": "42"
+      }
     }
   }
 }


### PR DESCRIPTION
Not entirely sure if we should support multiple formats and if we should still have a convenient way of having tison-encoded json maps as the default.