### PR TITLE
Drop alias requirements.

### DIFF
--- a/supabase_artemis/supabase/migrations/20231013101848_drop-uniq-alias.sql
+++ b/supabase_artemis/supabase/migrations/20231013101848_drop-uniq-alias.sql
@@ -1,0 +1,6 @@
+-- Copyright (C) 2022 Toitware ApS. All rights reserved.
+
+-- We do allow customers to reuse alias IDs.
+
+ALTER TABLE toit_artemis.devices DROP CONSTRAINT fk_id;
+ALTER TABLE public.devices DROP CONSTRAINT devices_alias_key;


### PR DESCRIPTION
Broker alias-ids don't need to exist in the Artemis DB anymore. Alias IDs don't need to be unique anymore.