### PR TITLE
Use "envelope" instead of "firmware-envelope" in pod specification.

### DIFF
--- a/src/cli/cmds/doc.toit
+++ b/src/cli/cmds/doc.toit
@@ -27,7 +27,7 @@ SPECIFICATION-FORMAT-HELP ::= """
   'artemis-version': The Artemis service version to use. This is a typically
       a string of the form 'v<major>.<minor>.<patch>'; for example 'v1.2.3'.
       Use 'sdk list' to see all available sdk-artemis combinations.
-  'firmware-envelope': optional. The firmware envelope to use. This can be a
+  'envelope': optional. The firmware envelope to use. This can be a
       variant name available from https://github.com/toitlang/envelopes (for
       example 'esp32-ota-1c0000'), a path URI to a local envelope (for
       example 'file:///path/to/envelope'), or a URI to a remote envelope (for

--- a/src/cli/pod-specification.toit
+++ b/src/cli/pod-specification.toit
@@ -291,13 +291,17 @@ class PodSpecification:
     name = get-string_ data "name"
     artemis-version = get-string_ data "artemis-version"
     sdk-version = get-optional-string_ data "sdk-version"
-    envelope = get-optional-string_ data "firmware-envelope"
+    firmware-envelope := get-optional-string_ data "firmware-envelope"
+    envelope = get-optional-string_ data "envelope"
+    if envelope and firmware-envelope:
+      format-error_ "Both 'firmware-envelope' and 'envelope' are present in pod specification."
+    if not envelope: envelope = firmware-envelope
 
     if sdk-version and not semver.is-valid sdk-version:
       format-error_ "Invalid sdk-version: $sdk-version"
 
     if not sdk-version and not envelope:
-      format-error_ "Neither 'sdk-version' nor 'firmware-envelope' are present in pod specification."
+      format-error_ "Neither 'sdk-version' nor 'envelope' are present in pod specification."
 
     chip = get-optional-string_ data "chip"
 

--- a/tests/cmd-pod-build-test.toit
+++ b/tests/cmd-pod-build-test.toit
@@ -45,7 +45,7 @@ run-test test-cli/TestCli fleet-dir/string:
   spec = {
       "\$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
       "name": "test-pod2",
-      "firmware-envelope": "file://custom.envelope",
+      "envelope": "file://custom.envelope",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
       "connections": [
         {

--- a/tests/parse-pod-specification-test.toit
+++ b/tests/parse-pod-specification-test.toit
@@ -74,13 +74,13 @@ new-valid -> Map:
 
 test-custom-envelope:
   custom-envelope := new-valid
-  custom-envelope["firmware-envelope"] = "envelope-path"
+  custom-envelope["envelope"] = "envelope-path"
   custom-envelope.remove "sdk-version"
   pod := PodSpecification.from-json custom-envelope --path="ignored"
   expect-equals "envelope-path" pod.envelope
 
   version-and-envelope := new-valid
-  version-and-envelope["firmware-envelope"] = "envelope-path"
+  version-and-envelope["envelope"] = "envelope-path"
   pod = PodSpecification.from-json version-and-envelope --path="ignored"
   expect-equals "envelope-path" pod.envelope
   expect-equals "1.0.0" pod.sdk-version
@@ -113,7 +113,7 @@ test-errors:
   no-sdk-version := new-valid
   no-sdk-version.remove "sdk-version"
   expect-format-error
-      "Neither 'sdk-version' nor 'firmware-envelope' are present in pod specification."
+      "Neither 'sdk-version' nor 'envelope' are present in pod specification."
       no-sdk-version
 
   bad-sdk-version := new-valid

--- a/tests/qemu-base/base.yaml
+++ b/tests/qemu-base/base.yaml
@@ -1,6 +1,6 @@
 version: 1
 name: my-pod
-firmware-envelope: esp32-qemu
+envelope: esp32-qemu
 connections:
   - type: ethernet
     requires:

--- a/tools/service_image_uploader/sdk-downloader.toit
+++ b/tools/service_image_uploader/sdk-downloader.toit
@@ -60,7 +60,7 @@ main --config/cli.Config --cache/cli.Cache --ui/ui.Ui args:
 pod-specification-for_ --sdk-version/string --envelope/string:
   json := INITIAL-POD-SPECIFICATION
   json["sdk-version"] = sdk-version
-  json["firmware-envelope"] = envelope
+  json["envelope"] = envelope
   return PodSpecification.from-json json --path="ignored"
 
 download config/cli.Config cache/cli.Cache ui/ui.Ui parsed/cli.Parsed:


### PR DESCRIPTION
The json-schema already uses "envelope".