### PR TITLE
Remove resource-lock workaround for cmake.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,11 +21,7 @@ ProcessorCount(NUM_CPU)
 
 add_custom_target(
   check
-  # Disable parallel builds until cmake has been updated.
-  # Version 3.29.0 doesn't respect resource locks:
-  #  https://gitlab.kitware.com/cmake/cmake/-/issues/25843
-  # COMMAND ${CMAKE_CTEST_COMMAND} -j${NUM_CPU} -T test --output-on-failure -C default
-  COMMAND ${CMAKE_CTEST_COMMAND} -j1 -T test --output-on-failure -C default
+  COMMAND ${CMAKE_CTEST_COMMAND} -j${NUM_CPU} -T test --output-on-failure -C default
   USES_TERMINAL
 )
 


### PR DESCRIPTION
The cmake version on the GitHub runners has been updated.