### PR TITLE
Avoid data leak.

### DIFF
--- a/supabase_artemis/supabase/migrations/20240527143236_remove_privileges.sql
+++ b/supabase_artemis/supabase/migrations/20240527143236_remove_privileges.sql
@@ -9,4 +9,3 @@ REVOKE ALL PRIVILEGES
 REVOKE ALL PRIVILEGES
   ON public.organization_admins
   FROM anon, authenticated;
-

--- a/supabase_artemis/supabase/migrations/20240527143236_remove_privileges.sql
+++ b/supabase_artemis/supabase/migrations/20240527143236_remove_privileges.sql
@@ -1,0 +1,12 @@
+-- Copyright (C) 2024 Toitware ApS.
+-- Use of this source code is governed by an MIT-style license that can be
+-- found in the LICENSE file.
+
+REVOKE ALL PRIVILEGES
+  ON public.admin_with_profile
+  FROM anon, authenticated;
+
+REVOKE ALL PRIVILEGES
+  ON public.organization_admins
+  FROM anon, authenticated;
+


### PR DESCRIPTION
These tables are only used for us internally and can still be accessed through the Studio page.