### PR TITLE
Support newer versions of envelopes.

### DIFF
--- a/src/cli/sdk.toit
+++ b/src/cli/sdk.toit
@@ -328,7 +328,12 @@ class Sdk:
   */
   static get-sdk-version-from --envelope/ByteArray -> string:
     reader := ar.ArReader.from-bytes envelope
-    file := reader.find "\$sdk-version"
+    // Newer versions of envelopes have a metadata file.
+    file := reader.find "\$metadata"
+    if file != null:
+      metadata := json.decode file.content
+      return metadata["sdk-version"]
+    file = reader.find "\$sdk-version"
     if file == null: throw "SDK version not found in envelope."
     return file.content.to-string
 

--- a/src/cli/sdk.toit
+++ b/src/cli/sdk.toit
@@ -333,6 +333,8 @@ class Sdk:
     if file != null:
       metadata := json.decode file.content
       return metadata["sdk-version"]
+    // Restart the reader from the beginning.
+    reader = ar.ArReader.from-bytes envelope
     file = reader.find "\$sdk-version"
     if file == null: throw "SDK version not found in envelope."
     return file.content.to-string


### PR DESCRIPTION
Envelopes now have a `$metadata` file (containing a json map), instead of an `$sdk-version` file.