### PR TITLE
Use more efficient way to transfer service images.

### DIFF
--- a/src/cli/artemis_servers/http/base.toit
+++ b/src/cli/artemis_servers/http/base.toit
@@ -174,10 +174,9 @@ class ArtemisServerCliHttpToit implements ArtemisServerCli:
     }
 
   download-service-image image/string -> ByteArray:
-    encoded-image := send-request_ COMMAND-DOWNLOAD-SERVICE-IMAGE_ {
+    return send-request_ COMMAND-DOWNLOAD-SERVICE-IMAGE_ {
       "image": image,
     }
-    return base64.decode encoded-image
 
   send-request_ command/int data/Map -> any:
     encoded/ByteArray := #[command] + (json.encode data)
@@ -197,6 +196,10 @@ class ArtemisServerCliHttpToit implements ArtemisServerCli:
 
     if response.status-code != http.STATUS-OK and response.status-code != http.STATUS-IM-A-TEAPOT:
       throw "HTTP error: $response.status-code $response.status-message"
+
+    if (command == COMMAND-DOWNLOAD-SERVICE-IMAGE_)
+        and response.status-code != http.STATUS-IM-A-TEAPOT:
+      return utils.read-all response.body
 
     decoded := json.decode-stream response.body
     if response.status-code == http.STATUS-IM-A-TEAPOT:

--- a/tools/service_image_uploader/client.toit
+++ b/tools/service_image_uploader/client.toit
@@ -178,11 +178,10 @@ class UploadClientHttp implements UploadClient:
       --organization-id/string?
       --force/bool:
     // We only upload the image.
-    send-request_ COMMAND-UPLOAD-SERVICE-IMAGE_ {
+    send-request_ COMMAND-UPLOAD-SERVICE-IMAGE_ --content=image-content {
       "sdk_version": sdk-version,
       "service_version": service-version,
       "image_id": image-id,
-      "image_content": base64.encode image-content,
       "organization_id": organization-id,
       "force": force,
     }
@@ -191,8 +190,9 @@ class UploadClientHttp implements UploadClient:
     throw "UNIMPLEMENTED"
 
   // TODO(florian): share this code with the cli and the service.
-  send-request_ command/int data/Map -> any:
-    encoded := #[command] + (json.encode data)
+  send-request_ command/int meta-data/Map --content/ByteArray -> any:
+    encoded-meta := json.encode meta-data
+    encoded := #[command] + encoded-meta + #[0] + content
 
     headers := null
     if server-config_.admin-headers:


### PR DESCRIPTION
For the HTTP version (only used during testing) the encoding of service images was really inefficient.