### PR TITLE
Deprecate/remove chip.

### DIFF
--- a/public/schemas/pod-specification/v1.json
+++ b/public/schemas/pod-specification/v1.json
@@ -36,15 +36,6 @@
           "description": "Firmware envelope to use. May be a short identifier or a URL. The string '$sdk-version' is replaced by the actual sdk-version.",
           "type": "string"
         },
-        "chip": {
-          "description": "The ESP32 chip that is used.",
-          "enum": [
-            "esp32",
-            "esp32s2",
-            "esp32c3",
-            "esp32s3"
-          ]
-        },
         "max-offline": {
           "description": "Maximum duration before Artemis should attempt to synchronize. For example '30m'.",
           "type": "string"

--- a/src/cli/firmware.toit
+++ b/src/cli/firmware.toit
@@ -332,7 +332,7 @@ get-envelope -> string
     --cache/cli.Cache
     --cache-snapshots/bool=true:
   if is-dev-setup:
-    chip := specification.chip or specification.envelope or "esp32"
+    chip := specification.envelope
     local-sdk := os.env.get "DEV_TOIT_REPO_PATH"
     if local-sdk:
       envelope-path := "$local-sdk/build/$chip/firmware.envelope"
@@ -342,7 +342,7 @@ get-envelope -> string
       return envelope-path
 
   sdk-version := specification.sdk-version
-  envelope := specification.envelope or specification.chip or "esp32"
+  envelope := specification.envelope
 
   url := build-envelope-url --sdk-version=sdk-version --envelope=envelope
 

--- a/src/cli/firmware.toit
+++ b/src/cli/firmware.toit
@@ -332,10 +332,10 @@ get-envelope -> string
     --cache/cli.Cache
     --cache-snapshots/bool=true:
   if is-dev-setup:
-    chip := specification.envelope
+    envelope := specification.envelope
     local-sdk := os.env.get "DEV_TOIT_REPO_PATH"
     if local-sdk:
-      envelope-path := "$local-sdk/build/$chip/firmware.envelope"
+      envelope-path := "$local-sdk/build/$envelope/firmware.envelope"
       if not reported-local-envelope-use_:
         print-on-stderr_ "Using envelope from local SDK: '$envelope-path'"
         reported-local-envelope-use_ = true

--- a/src/cli/pod-specification.toit
+++ b/src/cli/pod-specification.toit
@@ -27,6 +27,7 @@ INITIAL-POD-SPECIFICATION -> Map:
     "sdk-version": SDK-VERSION,
     "artemis-version": ARTEMIS-VERSION,
     "max-offline": "0s",
+    "firmware-envelope": "esp32",
     "connections": [
       {
         "type": "wifi",
@@ -44,6 +45,7 @@ EXAMPLE-POD-SPECIFICATION -> Map:
     "sdk-version": SDK-VERSION,
     "artemis-version": ARTEMIS-VERSION,
     "max-offline": "30s",
+    "firmware-envelope": "esp32",
     "connections": [
       {
         "type": "wifi",
@@ -304,11 +306,12 @@ class PodSpecification:
     chip := json-map.get-optional-string "chip"
     if not json-envelope and not chip:
       ui.warning "Implicit envelope 'esp32' is deprecated. Please specify 'firmware-envelope'."
-      envelope = "esp32"
+      json-envelope = "esp32"
     else if not json-envelope and chip:
       ui.warning "The 'chip' property is deprecated. Use 'firmware-envelope' instead."
+      json-envelope = chip
     else if json-envelope and chip:
-      ui.warning "The 'chip' property is deprecated. Only 'firmware-envelope' is used."
+      ui.warning "The 'chip' property is deprecated and ignored. Only 'firmware-envelope' is used."
 
     envelope = json-envelope
 

--- a/src/cli/pod-specification.toit
+++ b/src/cli/pod-specification.toit
@@ -281,28 +281,36 @@ Relevant data includes (but is not limited to):
 class PodSpecification:
   name/string
   sdk-version/string?
-  envelope/string?
+  envelope/string
   artemis-version/string
   max-offline-seconds/int
   connections/List  // Of $ConnectionInfo.
   containers/Map  // Of name -> $Container.
   path/string
-  chip/string?
 
   constructor.from-json --.path/string data/Map --ui/Ui:
     json-map := JsonMap data --holder="pod specification" --ui=ui
     name = json-map.get-string "name"
     artemis-version = json-map.get-string "artemis-version"
     sdk-version = json-map.get-optional-string "sdk-version"
-    envelope = json-map.get-optional-string "firmware-envelope"
+    json-envelope := json-map.get-optional-string "firmware-envelope"
 
     if sdk-version and not semver.is-valid sdk-version:
       format-error_ "Invalid sdk-version: $sdk-version"
 
-    if not sdk-version and not envelope:
-      format-error_ "Neither 'sdk-version' nor 'firmware-envelope' are present in pod specification."
+    if not sdk-version:
+      ui.warning "Implicit 'sdk-version' is deprecated. Please specify 'sdk-version'."
 
-    chip = json-map.get-optional-string "chip"
+    chip := json-map.get-optional-string "chip"
+    if not json-envelope and not chip:
+      ui.warning "Implicit envelope 'esp32' is deprecated. Please specify 'firmware-envelope'."
+      envelope = "esp32"
+    else if not json-envelope and chip:
+      ui.warning "The 'chip' property is deprecated. Use 'firmware-envelope' instead."
+    else if json-envelope and chip:
+      ui.warning "The 'chip' property is deprecated. Only 'firmware-envelope' is used."
+
+    envelope = json-envelope
 
     if json-map.has-key "apps" and json-map.has-key "containers":
       format-error_ "Both 'apps' and 'containers' are present in pod specification."

--- a/src/cli/sdk.toit
+++ b/src/cli/sdk.toit
@@ -234,7 +234,8 @@ class Sdk:
     if (semver.compare version "v2.0.0-alpha.150") < 0:
       throw "Unsupported for SDK versions older than v2.0.0-alpha.150"
     firmware-tool := tools-executable "firmware"
-    json-output := pipe.backticks [firmware-tool, "show", "--format", "json", "-e", envelope-path]
+    pipe.run-program [firmware-tool, "show", "--output-format", "json", "-e", envelope-path]
+    json-output := pipe.backticks [firmware-tool, "show", "--output-format", "json", "-e", envelope-path]
     decoded := json.parse json-output.trim
     return decoded.get "chip"
 

--- a/src/cli/sdk.toit
+++ b/src/cli/sdk.toit
@@ -230,6 +230,14 @@ class Sdk:
     ]
     run-firmware-tool args
 
+  chip-for --envelope-path/string -> string?:
+    if (semver.compare version "v2.0.0-alpha.150") < 0:
+      throw "Unsupported for SDK versions older than v2.0.0-alpha.150"
+    firmware-tool := tools-executable "firmware"
+    json-output := pipe.backticks [firmware-tool, "show", "--format", "json", "-e", envelope-path]
+    decoded := json.parse json-output.trim
+    return decoded.get "chip"
+
   /**
   Flashes the given envelope to the device at $port with the given $baud-rate.
 
@@ -239,16 +247,14 @@ class Sdk:
   flash
       --envelope-path/string
       --config-path/string
-      --chip/string
       --port/string
       --baud-rate/string?
       --partitions/List?:
-    // TODO(kasper): We'd like to get the chip variant from the firmware
-    // envelope, but for now we just treat the prefix leading up to
-    // the first dash as the variant. This works well with the current
-    // naming convention.
-    dash-index := chip.index-of "-"
-    if dash-index > 0: chip = chip[..dash-index]
+    if (semver.compare version "v2.0.0-alpha.150") < 0:
+      throw "Flashing is not supported for SDK versions older than v2.0.0-alpha.150"
+
+    // TODO(florian): we shouldn't need to pass `chip` to the firmware tool.
+    chip := chip-for --envelope-path=envelope-path
 
     arguments := [
       "flash",
@@ -270,15 +276,7 @@ class Sdk:
       --output-path/string
       --envelope-path/string
       --config-path/string
-      --partitions/List?
-      --chip/string:
-    // TODO(kasper): We'd like to get the chip variant from the firmware
-    // envelope, but for now we just treat the prefix leading up to
-    // the first dash as the variant. This works well with the current
-    // naming convention.
-    dash-index := chip.index-of "-"
-    if dash-index > 0: chip = chip[..dash-index]
-
+      --partitions/List?:
     if partitions and not partitions.is-empty:
       throw "Partitions are not supported for QEMU images."
 
@@ -367,7 +365,6 @@ class Sdk:
       // Currently the kind and chip-family align.
       return metadata["kind"]
     return "esp32"
-
 
 /**
 Builds the URL of a released SDK with the given $version on GitHub.

--- a/tests/cmd-pod-build-test.toit
+++ b/tests/cmd-pod-build-test.toit
@@ -23,6 +23,7 @@ run-test test-cli/TestCli fleet-dir/string:
       "name": "test-pod",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",
@@ -45,6 +46,7 @@ run-test test-cli/TestCli fleet-dir/string:
   spec = {
       "\$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
       "name": "test-pod2",
+      "sdk-version": "$test-cli.sdk-version",
       "firmware-envelope": "file://custom.envelope",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
       "connections": [
@@ -91,6 +93,7 @@ run-test test-cli/TestCli fleet-dir/string:
       "name": "test-pod3",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",
@@ -126,6 +129,7 @@ run-test test-cli/TestCli fleet-dir/string:
       "name": "test-pod4",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",
@@ -166,6 +170,7 @@ get-envelope-for --sdk-version/string --cache -> ByteArray:
       "name": "test-pod2",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
       "sdk-version": "$sdk-version",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",

--- a/tests/cmd-pod-delete-test.toit
+++ b/tests/cmd-pod-delete-test.toit
@@ -17,6 +17,7 @@ create-pods name/string test-cli/TestCli fleet-dir/string --count/int -> List:
       "name": "$name",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",

--- a/tests/cmd-pod-list-test-slow.toit
+++ b/tests/cmd-pod-list-test-slow.toit
@@ -20,6 +20,7 @@ run-test test-cli/TestCli fleet-dir/string:
       "name": "$name",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",

--- a/tests/cmd-pod-print-test.toit
+++ b/tests/cmd-pod-print-test.toit
@@ -10,6 +10,7 @@ MINIMAL-SPEC ::= {
   "name": "test-pod-print",
   "sdk-version": "v0.0.0",
   "artemis-version": "v1.0.0",
+  "firmware-envelope": "esp32",
 }
 
 EXTENDED-SPEC ::= {

--- a/tests/cmd-pod-upload-tag-test-slow.toit
+++ b/tests/cmd-pod-upload-tag-test-slow.toit
@@ -31,6 +31,7 @@ run-test test-cli/TestCli fleet-dir/string:
       "name": "$name",
       "sdk-version": "$test-cli.sdk-version",
       "artemis-version": "$TEST-ARTEMIS-VERSION",
+      "firmware-envelope": "esp32",
       "connections": [
         {
           "type": "wifi",

--- a/tests/gold/cmd-pod-print-test/AAA-print-spec.txt
+++ b/tests/gold/cmd-pod-print-test/AAA-print-spec.txt
@@ -4,6 +4,7 @@
   "$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
   "name": "test-pod-print",
   "sdk-version": "v0.0.0",
-  "artemis-version": "v1.0.0"
+  "artemis-version": "v1.0.0",
+  "firmware-envelope": "esp32"
 }
 

--- a/tests/gold/cmd-pod-print-test/BAA-print-spec-flat.txt
+++ b/tests/gold/cmd-pod-print-test/BAA-print-spec-flat.txt
@@ -4,6 +4,7 @@
   "$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
   "name": "test-pod-print",
   "sdk-version": "v0.0.0",
-  "artemis-version": "v1.0.0"
+  "artemis-version": "v1.0.0",
+  "firmware-envelope": "esp32"
 }
 

--- a/tests/gold/cmd-pod-print-test/DAA-print-spec-flat.txt
+++ b/tests/gold/cmd-pod-print-test/DAA-print-spec-flat.txt
@@ -5,6 +5,7 @@
   "$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
   "name": "test-pod-print",
   "sdk-version": "v0.0.0",
-  "artemis-version": "v1.0.0"
+  "artemis-version": "v1.0.0",
+  "firmware-envelope": "esp32"
 }
 

--- a/tests/parse-pod-specification-test.toit
+++ b/tests/parse-pod-specification-test.toit
@@ -33,6 +33,7 @@ VALID-SPECIFICATION ::= {
   "sdk-version": "1.0.0",
   "artemis-version": "1.0.0",
   "max-offline": "1h",
+  "firmware-envelope": "esp32",
   "connections": [
     {
       "type": "wifi",
@@ -138,9 +139,36 @@ test-errors:
 
   no-sdk-version := new-valid
   no-sdk-version.remove "sdk-version"
-  expect-format-error
-      "Neither 'sdk-version' nor 'firmware-envelope' are present in pod specification."
-      no-sdk-version
+  ui := TestUi
+  PodSpecification.from-json no-sdk-version --path="ignored" --ui=ui
+  expect-equals
+      "Warning: Implicit 'sdk-version' is deprecated. Please specify 'sdk-version'."
+      ui.stdout.trim
+
+  no-envelope := new-valid
+  no-envelope.remove "firmware-envelope"
+  ui = TestUi
+  PodSpecification.from-json no-envelope --path="ignored" --ui=ui
+  expect-equals
+      "Warning: Implicit envelope 'esp32' is deprecated. Please specify 'firmware-envelope'."
+      ui.stdout.trim
+
+  no-envelope-chip := new-valid
+  no-envelope-chip.remove "firmware-envelope"
+  no-envelope-chip["chip"] = "esp32"
+  ui = TestUi
+  PodSpecification.from-json no-envelope-chip --path="ignored" --ui=ui
+  expect-equals
+      "Warning: The 'chip' property is deprecated. Use 'firmware-envelope' instead."
+      ui.stdout.trim
+
+  envelope-and-chip := new-valid
+  envelope-and-chip["chip"] = "esp32"
+  ui = TestUi
+  PodSpecification.from-json envelope-and-chip --path="ignored" --ui=ui
+  expect-equals
+      "Warning: The 'chip' property is deprecated and ignored. Only 'firmware-envelope' is used."
+      ui.stdout.trim
 
   bad-sdk-version := new-valid
   bad-sdk-version["sdk-version"] = 2

--- a/tests/pod-test.toit
+++ b/tests/pod-test.toit
@@ -9,7 +9,6 @@ main args:
     id := random-uuid
     pod := Pod
         --id=id
-        --chip="esp32"
         --name="name"
         --envelope="envelope".to-byte-array
         --tmp-directory=tmp-dir
@@ -20,5 +19,4 @@ main args:
     pod2 := Pod.parse out --ui=ui --tmp-directory=tmp-dir
     expect-equals id pod2.id
     expect-equals "name" pod2.name
-    expect-equals "esp32" pod2.chip
     expect-equals "envelope".to-byte-array pod2.envelope

--- a/tests/qemu.toit
+++ b/tests/qemu.toit
@@ -50,6 +50,8 @@ build-qemu-image -> Map
     pod-spec["sdk-version"] = test-cli.sdk-version
   if not pod-spec.contains "extends":
     pod-spec["extends"] = ["$qemu-base/base.yaml"]
+  if not pod-spec.contains "firmware-envelope":
+    pod-spec["firmware-envelope"] = "esp32"
 
   spec-path := "$tmp-dir/$pod-spec-filename"
   if spec-path.ends-with ".json":

--- a/tests/qemu.toit
+++ b/tests/qemu.toit
@@ -50,8 +50,7 @@ build-qemu-image -> Map
     pod-spec["sdk-version"] = test-cli.sdk-version
   if not pod-spec.contains "extends":
     pod-spec["extends"] = ["$qemu-base/base.yaml"]
-  if not pod-spec.contains "firmware-envelope":
-    pod-spec["firmware-envelope"] = "esp32"
+  // The base contains the firmware-envelope entry.
 
   spec-path := "$tmp-dir/$pod-spec-filename"
   if spec-path.ends-with ".json":

--- a/tests/serial.toit
+++ b/tests/serial.toit
@@ -55,6 +55,7 @@ flash-serial -> uuid.Uuid
   if not pod-spec.contains "name": pod-spec["name"] = "my-pod"
   if not pod-spec.contains "artemis-version": pod-spec["artemis-version"] = TEST-ARTEMIS-VERSION
   if not pod-spec.contains "sdk-version": pod-spec["sdk-version"] = test-cli.sdk-version
+  if not pod-spec.contains "firmware-envelope": pod-spec["firmware-envelope"] = "esp32"
 
   pod-name := pod-spec["name"]
 

--- a/tests/spec_extends_tests/basic_expected.json
+++ b/tests/spec_extends_tests/basic_expected.json
@@ -4,6 +4,7 @@
   "sdk-version": "1.0.0",
   "artemis-version": "1.0.0",
   "max-offline": "1h",
+  "firmware-envelope": "esp32",
   "connections": [
     {
       "type": "wifi",

--- a/tests/spec_extends_tests/basic_test.yaml
+++ b/tests/spec_extends_tests/basic_test.yaml
@@ -3,6 +3,7 @@ name: test-pod
 sdk-version: 1.0.0
 artemis-version: 1.0.0
 max-offline: 1h
+firmware-envelope: esp32
 connections:
   - type: wifi
     ssid: ssid

--- a/tests/spec_extends_tests/full_include_1.yaml
+++ b/tests/spec_extends_tests/full_include_1.yaml
@@ -3,6 +3,7 @@ name: test-pod
 sdk-version: 1.0.0
 artemis-version: 1.0.0
 max-offline: 1h
+firmware-envelope: esp32
 connections:
   - type: wifi
     ssid: ssid

--- a/tests/spec_extends_tests/full_include_expected.json
+++ b/tests/spec_extends_tests/full_include_expected.json
@@ -4,6 +4,7 @@
   "sdk-version": "1.0.0",
   "artemis-version": "1.0.0",
   "max-offline": "1h",
+  "firmware-envelope": "esp32",
   "connections": [
     {
       "type": "wifi",

--- a/tests/spec_extends_tests/nested_1_3.yaml
+++ b/tests/spec_extends_tests/nested_1_3.yaml
@@ -1,1 +1,2 @@
 artemis-version: 3.0.0
+firmware-envelope": esp32

--- a/tests/spec_extends_tests/nested_expected.json
+++ b/tests/spec_extends_tests/nested_expected.json
@@ -3,6 +3,7 @@
   "$schema": "https://toit.io/schemas/artemis/pod-specification/v1.json",
   "sdk-version": "1.0.0",
   "artemis-version": "3.0.0",
+  "firmware-envelope\"": "esp32",
   "connections": [
     {
       "type": "wifi",


### PR DESCRIPTION
Pods/pod specifications don't need to know which chip exactly they are built for. The envelope already contains that information.