### PR TITLE
Refactor.

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -1,11 +1,7 @@
 // Copyright (C) 2022 Toitware ApS. All rights reserved.
 
 import ar
-import crypto.sha256
 import host.file
-import host.os
-import io
-import log
 import net
 import uuid
 
@@ -14,21 +10,16 @@ import encoding.ubjson
 import encoding.json
 
 import .cache as cache
-import .cache show service-image-cache-key application-image-cache-key
+import .cache show service-image-cache-key
 import .config
 import .device
-import .pod
-import .pod-specification
 
 import .utils
-import .utils.patch-build show build-diff-patch build-trivial-patch
-import ..shared.utils.patch show Patcher PatchObserver
 
 import .artemis-servers.artemis-server
 import .brokers.broker
-import .firmware
-import .program
 import .sdk
+import .organization
 import .ui
 import .server-config
 
@@ -36,26 +27,19 @@ import .server-config
 Manages devices that have an Artemis service running on them.
 */
 class Artemis:
-  broker_/BrokerCli? := null
   artemis-server_/ArtemisServerCli? := null
   network_/net.Interface? := null
 
   config_/Config
   cache_/cache.Cache
   ui_/Ui
-  broker-config_/ServerConfig
-  artemis-config_/ServerConfig
+  server-config/ServerConfig
   tmp-directory/string
 
-  constructor --config/Config --cache/cache.Cache --ui/Ui
-      --.tmp-directory
-      --broker-config/ServerConfig
-      --artemis-config/ServerConfig:
+  constructor --config/Config --cache/cache.Cache --ui/Ui --.tmp-directory --.server-config:
     config_ = config
     cache_ = cache
     ui_ = ui
-    broker-config_ = broker-config
-    artemis-config_ = artemis-config
 
   /**
   Closes the manager.
@@ -63,10 +47,8 @@ class Artemis:
   If the manager opened any connections, closes them as well.
   */
   close:
-    if broker_: broker_.close
     if artemis-server_: artemis-server_.close
     if network_: network_.close
-    broker_ = null
     artemis-server_ = null
     network_ = null
 
@@ -76,38 +58,31 @@ class Artemis:
     network_ = net.open
 
   /**
-  Returns a connected broker, using the $broker-config_ to connect.
-
-  If $authenticated is true (the default), calls $BrokerCli.ensure-authenticated.
-  */
-  connected-broker --authenticated/bool=true -> BrokerCli:
-    if not broker_:
-      broker_ = BrokerCli broker-config_ config_
-    if authenticated:
-      broker_.ensure-authenticated: | error-message |
-        ui_.abort "$error-message (broker)."
-    return broker_
-
-  /**
-  Returns a connected broker, using the $artemis-config_ to connect.
+  Returns a connected artemis-server, using the $server-config to connect.
 
   If $authenticated is true (the default), calls $ArtemisServerCli.ensure-authenticated.
   */
-  connected-artemis-server --authenticated/bool=true -> ArtemisServerCli:
+  connected-artemis-server_ --authenticated/bool=true -> ArtemisServerCli:
     if not artemis-server_:
       connect-network_
-      artemis-server_ = ArtemisServerCli network_ artemis-config_ config_
+      artemis-server_ = ArtemisServerCli network_ server-config config_
     if authenticated:
       artemis-server_.ensure-authenticated: | error-message |
         ui_.abort "$error-message (artemis)."
     return artemis-server_
 
   /**
+  Ensures that the user is authenticated with the Artemis server.
+  */
+  ensure-authenticated -> none:
+    connected-artemis-server_
+
+  /**
   Checks whether the given $sdk version and $service version is supported by
     the Artemis server.
   */
   check-is-supported-version_ --organization-id/uuid.Uuid --sdk/string?=null --service/string?=null:
-    server := connected-artemis-server
+    server := connected-artemis-server_
     versions := server.list-sdk-service-versions
         --organization-id=organization-id
         --sdk-version=sdk
@@ -115,511 +90,21 @@ class Artemis:
     if versions.is-empty:
       ui_.abort "Unsupported Artemis/SDK versions ($service/$sdk)."
 
-  /**
-  Provisions a device.
-
-  Contacts the Artemis server and creates a new device entry with the
-    given $device-id (used as "alias" on the server side) in the
-    organization with the given $organization-id.
-
-  Writes the identity file to $out-path.
-  */
-  provision --device-id/uuid.Uuid? --out-path/string --organization-id/uuid.Uuid:
-    server := connected-artemis-server
-    // Get the broker just after the server, in case it needs to authenticate.
-    // We prefer to get an error message before we created a device on the
-    // Artemis server.
-    broker := connected-broker
-
-    device := server.create-device-in-organization
-        --device-id=device-id
-        --organization-id=organization-id
-    assert: device.id == device-id
-    hardware-id := device.hardware-id
-
-    // Insert an initial event mostly for testing purposes.
+  notify-created --hardware-id/uuid.Uuid:
+    server := connected-artemis-server_
     server.notify-created --hardware-id=hardware-id
 
-    identity := {
-      "device_id": "$device-id",
-      "organization_id": "$organization-id",
-      "hardware_id": "$hardware-id",
-    }
-    state := {
-      "identity": identity,
-    }
-    broker.notify-created --device-id=device-id --state=state
-
-    write-identity-file
-        --out-path=out-path
+  create-device --device-id/uuid.Uuid? --organization-id/uuid.Uuid -> Device:
+    return connected-artemis-server_.create-device-in-organization
         --device-id=device-id
         --organization-id=organization-id
-        --hardware-id=hardware-id
-
-  static device-from --identity-path/string -> Device:
-    identity := ubjson.decode (base64.decode (file.read-content identity-path))
-    device-map := identity["artemis.device"]
-    return Device
-        --hardware-id=uuid.parse device-map["hardware_id"]
-        --id=uuid.parse device-map["device_id"]
-        --organization-id=uuid.parse device-map["organization_id"]
-
-  /**
-  Writes an identity file.
-
-  This file is used to build a device image and needs to be given to
-    $compute-device-specific-data.
-  */
-  write-identity-file -> none
-      --out-path/string
-      --device-id/uuid.Uuid
-      --organization-id/uuid.Uuid
-      --hardware-id/uuid.Uuid:
-    // A map from id to DER certificates.
-    der-certificates := {:}
-
-    broker-json := server-config-to-service-json broker-config_ der-certificates
-    artemis-json := server-config-to-service-json artemis-config_ der-certificates
-
-    identity ::= {
-      "artemis.device": {
-        "device_id"       : "$device-id",
-        "organization_id" : "$organization-id",
-        "hardware_id"     : "$hardware-id",
-      },
-      "artemis.broker": artemis-json,
-      "broker": broker-json,
-    }
-
-    // Add the necessary certificates to the identity.
-    der-certificates.do: | name/string content/ByteArray |
-      // The 'server_config_to_service_json' function puts the certificates
-      // into their own namespace.
-      assert: name.starts-with "certificate-"
-      identity[name] = content
-
-    write-base64-ubjson-to-file out-path identity
-
-  has-implicit-network_ chip-family/string -> bool:
-    return chip-family == "host"
-
-  /**
-  Customizes a generic Toit envelope with the given $specification.
-    Also installs the Artemis service.
-
-  The image is ready to be flashed together with the identity file.
-  */
-  customize-envelope
-      --organization-id/uuid.Uuid
-      --specification/PodSpecification
-      --output-path/string:
-    service-version := specification.artemis-version
-    sdk-version := specification.sdk-version
-
-    checked := false
-    // We try to check the sdk and service versions as soon as possible to
-    // avoid downloading expensive assets.
-    check-sdk-service-version := :
-      if not checked and sdk-version:
-        check-is-supported-version_
-            --organization-id=organization-id
-            --sdk=sdk-version
-            --service=service-version
-        checked = true
-
-    check-sdk-service-version.call
-
-    envelope-path := get-envelope
-        --specification=specification
-        --cache=cache_
-
-    // Extract the sdk version from the envelope.
-    envelope := file.read-content envelope-path
-    envelope-sdk-version := Sdk.get-sdk-version-from --envelope=envelope
-    envelope-chip-family := Sdk.get-chip-family-from --envelope=envelope
-    if sdk-version:
-      if sdk-version != envelope-sdk-version:
-        if not (is-dev-setup and os.env.get "DEV_TOIT_REPO_PATH"):
-          ui_.abort "The envelope uses SDK version '$envelope-sdk-version', but '$sdk-version' was requested."
-    else:
-      sdk-version = envelope-sdk-version
-      check-sdk-service-version.call
-    envelope-word-bit-size := Sdk.get-word-bit-size-from --envelope=envelope
-
-    sdk := get-sdk sdk-version --cache=cache_
-
-    copy-file --source=envelope-path --target=output-path
-
-    device-config := {
-      "sdk-version": sdk-version,
-    }
-
-    // Add the max-offline setting if is non-zero. The device service
-    // handles the absence of the max-offline setting differently, so
-    // we cannot just add zero seconds to the config. This matches what
-    // we do in $config_set_max_offline.
-    max-offline-seconds := specification.max-offline-seconds
-    if max-offline-seconds > 0: device-config["max-offline"] = max-offline-seconds
-
-    if specification.connections.is-empty and not has-implicit-network_ envelope-chip-family:
-      ui_.warning "No network connections configured."
-    connections := specification.connections.map: | connection/ConnectionInfo |
-      connection.to-json
-    device-config["connections"] = connections
-
-    // Create the assets for the Artemis service.
-    // TODO(florian): share this code with the identity creation code.
-    der-certificates := {:}
-    broker-json := server-config-to-service-json broker-config_ der-certificates
-    artemis-json := server-config-to-service-json artemis-config_ der-certificates
-
-    with-tmp-directory: | tmp-dir |
-      // Store the containers in the envelope.
-      specification.containers.do: | name/string container/Container |
-        snapshot-path := "$tmp-dir/$(name).snapshot"
-        container.build-snapshot
-            --relative-to=specification.relative-to
-            --sdk=sdk
-            --output-path=snapshot-path
-            --cache=cache_
-            --ui=ui_
-
-        // Build the assets from the defines (if any).
-        assets-path/string? := null
-        if container.defines:
-          assets-path = "$tmp-dir/$(name).assets"
-          assets := {
-            "artemis.defines": {
-              "format": "tison",
-              "json": container.defines
-            }
-          }
-          sdk.assets-create --output-path=assets-path assets
-
-        sdk.firmware-add-container name
-            --envelope=output-path
-            --assets=assets-path
-            --program-path=snapshot-path
-            --trigger="none"
-
-        // TODO(kasper): Avoid computing the image id here. We should
-        // be able to get it from the firmware tool.
-        sha := sha256.Sha256
-        snapshot-uuid-string := extract-id-from-snapshot snapshot-path
-        sha.add (uuid.parse snapshot-uuid-string).to-byte-array
-        if assets-path:
-          sha.add (file.read-content assets-path)
-        id := uuid.Uuid sha.get[..uuid.SIZE]
-
-        triggers := container.triggers
-        if not container.is-critical and not triggers:
-          // Non-critical containers default to having a boot trigger.
-          triggers = [BootTrigger]
-        apps := device-config.get "apps" --init=:{:}
-        apps[name] = build-container-description_
-            --id=id
-            --arguments=container.arguments
-            --background=container.is-background
-            --critical=container.is-critical
-            --runlevel=container.runlevel
-            --triggers=triggers
-        ui_.info "Added container '$name' to envelope."
-
-      artemis-assets := {
-        // TODO(florian): share the keys of the assets with the Artemis service.
-        "broker": {
-          "format": "tison",
-          "json": broker-json,
-        },
-        "artemis.broker": {
-          "format": "tison",
-          "json": artemis-json,
-        },
-      }
-      der-certificates.do: | name/string value/ByteArray |
-        // The 'server_config_to_service_json' function puts the certificates
-        // into their own namespace.
-        assert: name.starts-with "certificate-"
-        artemis-assets[name] = {
-          "format": "binary",
-          "blob": value,
-        }
-
-      artemis-assets["device-config"] = {
-        "format": "ubjson",
-        "json": device-config,
-      }
-
-      artemis-assets-path := "$tmp-dir/artemis.assets"
-      sdk.assets-create --output-path=artemis-assets-path artemis-assets
-
-      // Get the prebuilt Artemis service.
-      artemis-service-image-path := get-service-image-path_
-          --organization-id=organization-id
-          --chip-family=envelope-chip-family
-          --word-size=envelope-word-bit-size
-          --sdk=sdk-version
-          --service=service-version
-
-      sdk.firmware-add-container "artemis"
-          --envelope=output-path
-          --assets=artemis-assets-path
-          --program-path=artemis-service-image-path
-          --trigger="boot"
-          --critical
-
-    // For convenience save all snapshots in the user's cache.
-    cache-snapshots --envelope-path=output-path --cache=cache_
-
-  /**
-  Builds a container description as needed for a "container" entry in the device state.
-  */
-  build-container-description_ -> Map
-      --id/uuid.Uuid
-      --arguments/List?
-      --background/bool?
-      --critical/bool?
-      --runlevel/int?
-      --triggers/List?:
-    result := {
-      "id": id.stringify,
-    }
-    if arguments and not arguments.is-empty:
-      result["arguments"] = arguments
-    if background:
-      result["background"] = 1
-    if critical:
-      result["critical"] = 1
-    if runlevel:
-      result["runlevel"] = runlevel
-    if triggers and not triggers.is-empty:
-      trigger-map := {:}
-      triggers.do: | trigger/Trigger |
-        assert: not trigger-map.contains trigger.type
-        trigger-map[trigger.type] = trigger.json-value
-      result["triggers"] = trigger-map
-    return result
-
-  /**
-  Uploads the given $pod to the server under the given $organization-id.
-
-  Uploads the trivial patches and the pod itself.
-
-  Once uploaded, the pod can be used for diff-based updates, or simply as direct
-    downloads for updates.
-  */
-  upload --pod/Pod --organization-id/uuid.Uuid:
-    firmware-content := FirmwareContent.from-envelope pod.envelope-path --cache=cache_
-    upload --firmware-content=firmware-content --organization-id=organization-id
-
-  upload --firmware-content/FirmwareContent --organization-id/uuid.Uuid:
-    firmware-content.trivial-patches.do:
-      upload-patch it --organization-id=organization-id
-  /**
-  Uploads the given $patch to the server under the given $organization-id.
-  */
-  upload-patch patch/FirmwarePatch --organization-id/uuid.Uuid:
-    diff-and-upload_ patch --organization-id=organization-id
-
-  /**
-  Extracts the trivial patches from the given $firmware-content.
-
-  Returns a mapping from patch-id (as used when diffing to the part) and
-    the patch itself.
-  */
-  extract-trivial-patches firmware-content/FirmwareContent -> Map:
-    result := {:}
-    firmware-content.trivial-patches.do: | patch/FirmwarePatch |
-      patch-id := id_ --to=patch.to_
-      result[patch-id] = patch
-    return result
-
-  device-for --id/uuid.Uuid -> DeviceDetailed:
-    devices := connected-broker.get-devices --device-ids=[id]
-    if devices.is-empty:
-      ui_.abort "Device '$id' not found."
-    return devices[id]
-
-  update --device-id/uuid.Uuid --pod/Pod --base-firmwares/List=[]:
-    update-bulk --devices=[device-for --id=device-id] --pods=[pod] --base-firmwares=base-firmwares
-
-  /**
-  Update the given $devices.
-
-  The lists $devices and $pods must have the same size.
-
-  The $devices list must contain $DeviceDetailed objects.
-  The $pods list must contain $Pod objects.
-
-  Uploads the $pods if they it haven't been uploaded yet.
-  For each device computes upgrade-patches and uploads them if needed.
-
-  If a device has no known current state, then uses the $base-firmwares
-    (a list of $FirmwareContent) for diff-based patches. If the list
-    is empty, the device must upgrade using trivial patches.
-
-  Trivial patches are always uploaded (as part of the pod upload).
-  */
-  update-bulk --devices/List --pods/List --base-firmwares/List=[] -> none:
-    unconfigured-cache := {:}
-
-    goals := []
-    devices.size.repeat: | i |
-      device := devices[i]
-      pod := pods[i]
-      unconfigured := unconfigured-cache.get pod.id --init=:
-        FirmwareContent.from-envelope pod.envelope-path --cache=cache_
-
-      goal := prepare-update-device_
-          --device=device
-          --pod=pod
-          --unconfigured-content=unconfigured
-          --base-firmwares=base-firmwares
-      goals.add goal
-
-    connected-broker.update-goals
-        --device-ids=devices.map: it.id
-        --goals=goals
-
-  /**
-  Prepares the update for the given $device.
-
-  Computes the patch and uploads it.
-  Returns the new goal state for the device.
-  */
-  prepare-update-device_ --device/DeviceDetailed --pod/Pod --unconfigured-content/FirmwareContent --base-firmwares/List -> Map:
-    device-id := device.id
-    upload --firmware-content=unconfigured-content --organization-id=device.organization-id
-
-    known-encoded-firmwares := {}
-    [
-      device.goal,
-      device.reported-state-firmware,
-      device.reported-state-current,
-      device.reported-state-goal,
-    ].do: | state/Map? |
-      // The device might be running this firmware.
-      if state: known-encoded-firmwares.add state["firmware"]
-
-    upgrade-from := []
-    if known-encoded-firmwares.is-empty:
-      if base-firmwares.is-empty:
-        ui_.warning "Firmware of device '$device-id' is unknown. Upgrade might not use patches."
-      else:
-        upgrade-from = base-firmwares
-    else:
-      known-encoded-firmwares.do: | encoded/string |
-        old-firmware := Firmware.encoded encoded
-        old-device-map := old-firmware.device-specific "artemis.device"
-        old-device-id := uuid.parse old-device-map["device_id"]
-        if device-id != old-device-id:
-          ui_.abort "The device id of the firmware image ($old-device-id) does not match the given device id ($device-id)."
-        upgrade-from.add old-firmware.content
-
-    result := compute-updated-goal
-        --device=device
-        --upgrade-from=upgrade-from
-        --pod=pod
-        --unconfigured-content=unconfigured-content
-    return result
-
-  /**
-  Computes the goal for the given $device, upgrading from the $upgrade-from
-    firmware content entries to the firmware image given by the $pod.
-
-  Uploads the patches to the broker in the same organization as the $device.
-
-  The returned goal state will instruct the device to download the firmware image
-    and install it.
-  */
-  compute-updated-goal --device/Device --upgrade-from/List --pod/Pod --unconfigured-content/FirmwareContent -> Map:
-    // Compute the patches and upload them.
-    ui_.info "Computing and uploading patches for $device.id."
-    upgrade-to := Firmware --pod=pod --device=device --cache=cache_ --unconfigured-content=unconfigured-content
-    upgrade-from.do: | old-firmware-content/FirmwareContent |
-      patches := upgrade-to.content.patches old-firmware-content
-      patches.do: diff-and-upload_ it --organization-id=device.organization-id
-
-    // Build the updated goal and return it.
-    sdk := get-sdk pod.sdk-version --cache=cache_
-    goal := (pod.device-config --sdk=sdk).copy
-    goal["firmware"] = upgrade-to.encoded
-    return goal
-
-  /**
-  Computes the device-specific data of the given envelope.
-
-  Combines the $pod and identity ($identity-path) into a single firmware image
-    and computes the configuration which depends on the checksums of the
-    individual parts.
-
-  In this context the configuration consists of the checksums of the individual
-    parts of the firmware image, combined with the configuration that was
-    stored in the envelope.
-  */
-  compute-device-specific-data --pod/Pod --identity-path/string -> ByteArray:
-    return compute-device-specific-data
-        --pod=pod
-        --identity-path=identity-path
-        --cache=cache_
-        --ui=ui_
-
-  /**
-  Variant of $(compute-device-specific-data --pod --identity-path).
-  */
-  static compute-device-specific-data -> ByteArray
-      --pod/Pod
-      --identity-path/string
-      --cache/cache.Cache
-      --ui/Ui:
-    // Use the SDK from the pod.
-    sdk := get-sdk pod.sdk-version --cache=cache
-
-    // Extract the device ID from the identity file.
-    // TODO(florian): abstract the identity management.
-    identity-raw := file.read-content identity-path
-
-    identity := ubjson.decode (base64.decode identity-raw)
-
-    // Since we already have the identity content, check that the artemis server
-    // is the same.
-    // This is primarily a sanity check, and we might remove the broker from the
-    // identity file in the future. Since users are not supposed to be able to
-    // change the Artemis server, there wouldn't be much left of the check.
-    // TODO(florian): remove this check?
-    with-tmp-directory: | tmp/string |
-      artemis-assets-path := "$tmp/artemis.assets"
-      sdk.run-firmware-tool [
-        "-e", pod.envelope-path,
-        "container", "extract",
-        "-o", artemis-assets-path,
-        "--part", "assets",
-        "artemis"
-      ]
-
-      if not is-same-broker "broker" identity tmp artemis-assets-path sdk:
-        ui.warning "The identity file and the Artemis assets in the envelope don't use the same broker"
-      if not is-same-broker "artemis.broker" identity tmp artemis-assets-path sdk:
-        ui.warning "The identity file and the Artemis assets in the envelope don't use the same Artemis server"
-
-    device-map := identity["artemis.device"]
-    device := Device
-        --hardware-id=uuid.parse device-map["hardware_id"]
-        --id=uuid.parse device-map["device_id"]
-        --organization-id=uuid.parse device-map["organization_id"]
-
-    // We don't really need the full firmware and just the device-specific data,
-    // but by cooking the firmware we get the checksums correct.
-    firmware := Firmware --pod=pod --device=device --cache=cache
-
-    return firmware.device-specific-data
 
   /**
   Gets the Artemis service image for the given $sdk and $service versions.
 
   Returns a path to the cached image.
   */
-  get-service-image-path_ -> string
+  get-service-image-path -> string
       --organization-id/uuid.Uuid
       --sdk/string
       --service/string
@@ -629,11 +114,11 @@ class Artemis:
     service-key := service-image-cache-key
         --service-version=service
         --sdk-version=sdk
-        --artemis-config=artemis-config_
+        --artemis-config=server-config
         --chip-family=chip-family
         --word-size=word-size
     return cache_.get-file-path service-key: | store/cache.FileStore |
-      server := connected-artemis-server --no-authenticated
+      server := connected-artemis-server_ --no-authenticated
       entry := server.list-sdk-service-versions
           --organization-id=organization-id
           --sdk-version=sdk
@@ -658,183 +143,29 @@ class Artemis:
         store.save ar-file.content
 
   /**
-  Updates the goal state of the device with the given $device-id.
+  Fetches the organizations with the given $id.
 
-  See $BrokerCli.update-goal.
+  Returns null if the organization doesn't exist.
   */
-  update-goal --device-id/uuid.Uuid [block]:
-    connected-broker.update-goal --device-id=device-id block
-
-  container-install -> none
-      --device-id/uuid.Uuid
-      --app-name/string
-      --application-path/string
-      --arguments/List?
-      --background/bool
-      --critical/bool
-      --triggers/List?:
-    update-goal --device-id=device-id: | device/DeviceDetailed |
-      current-state := device.reported-state-current or device.reported-state-firmware
-      if not current-state:
-        ui_.abort "Unknown device state."
-      firmware := Firmware.encoded current-state["firmware"]
-      sdk-version := firmware.sdk-version
-      sdk := get-sdk sdk-version --cache=cache_
-      program := CompiledProgram.application application-path --sdk=sdk
-      id := program.id
-
-      cache-id := application-image-cache-key id --broker-config=broker-config_
-      cache_.get-directory-path cache-id: | store/cache.DirectoryStore |
-        store.with-tmp-directory: | tmp-dir |
-          // TODO(florian): do we want to rely on the cache, or should we
-          // do a check to see if the files are really uploaded?
-          connected-broker.upload-image program.image32
-              --app-id=id
-              --organization-id=device.organization-id
-              --word-size=32
-          file.write-content program.image32 --path="$tmp-dir/image32.bin"
-          connected-broker.upload-image program.image64
-              --organization-id=device.organization-id
-              --app-id=id
-              --word-size=64
-          file.write-content program.image64 --path="$tmp-dir/image64.bin"
-          store.move tmp-dir
-
-      if not device.goal and not device.reported-state-firmware:
-        throw "No known firmware information for device."
-      new-goal := device.goal or device.reported-state-firmware
-      ui_.info "Installing container '$app-name'."
-      apps := new-goal.get "apps" --if-absent=: {:}
-      apps[app-name] = build-container-description_
-          --id=id
-          --arguments=arguments
-          --background=background
-          --critical=critical
-          --runlevel=null  // TODO(florian): should we allow to set the runlevel?
-          --triggers=triggers
-      new-goal["apps"] = apps
-      new-goal
-
-  container-uninstall --device-id/uuid.Uuid --app-name/string --force/bool:
-    update-goal --device-id=device-id: | device/DeviceDetailed |
-      if not device.goal and not device.reported-state-firmware:
-        throw "No known firmware information for device."
-      new-goal := device.goal or device.reported-state-firmware
-      connections/List := new-goal.get "connections" --if-absent=: []
-      is-required := false
-      connections.do:
-        required := it.get "requires" --if-absent=: []
-        if required.contains app-name:
-          is-required = true
-      if is-required and not force:
-        ui_.abort "Container '$app-name' is required by a connection."
-      apps := new-goal.get "apps"
-      if apps:
-        if not apps.contains app-name and not force:
-          ui_.abort "Container '$app-name' is not installed."
-        else:
-          ui_.info "Uninstalling container '$app-name'."
-          apps.remove app-name
-      new-goal
-
-  config-set-max-offline --device-id/uuid.Uuid --max-offline-seconds/int:
-    update-goal --device-id=device-id: | device/DeviceDetailed |
-      if not device.goal and not device.reported-state-firmware:
-        throw "No known firmware information for device."
-      new-goal := device.goal or device.reported-state-firmware
-      ui_.info "Setting max-offline to $(Duration --s=max-offline-seconds)."
-      if max-offline-seconds > 0:
-        new-goal["max-offline"] = max-offline-seconds
-      else:
-        new-goal.remove "max-offline"
-      new-goal
+  get-organization --id/uuid.Uuid -> OrganizationDetailed?:
+    return connected-artemis-server_.get-organization id
 
   /**
-  Computes patches and uploads them to the broker.
+  List all SDK/service version combinations.
+
+  Returns a list of maps with the following keys:
+  - "sdk_version": the SDK version
+  - "service_version": the service version
+  - "image": the name of the image
+
+  If provided, the given $sdk-version and $service-version can be
+    used to filter the results.
   */
-  diff-and-upload_ patch/FirmwarePatch --organization-id/uuid.Uuid -> none:
-    trivial-id := id_ --to=patch.to_
-    cache-key := "$connected-broker.id/$organization-id/patches/$trivial-id"
-
-    // Unless it is already cached, always create/upload the trivial one.
-    cache_.get cache-key: | store/cache.FileStore |
-      trivial := build-trivial-patch patch.bits_
-      connected-broker.upload-firmware trivial
-          --organization-id=organization-id
-          --firmware-id=trivial-id
-      store.save-via-writer: | writer/io.Writer |
-        trivial.do: writer.write it
-
-    if not patch.from_: return
-
-    // Attempt to fetch the old trivial patch and use it to construct
-    // the old bits so we can compute a diff from them.
-    old-id := id_ --to=patch.from_
-    cache-key = "$connected-broker.id/$organization-id/patches/$old-id"
-    trivial-old := cache_.get cache-key: | store/cache.FileStore |
-      downloaded := null
-      catch: downloaded = connected-broker.download-firmware
-          --organization-id=organization-id
-          --id=old-id
-      if not downloaded: return
-      store.with-tmp-directory: | tmp-dir |
-        file.write-content downloaded --path="$tmp-dir/patch"
-        // TODO(florian): we don't have the chunk-size when downloading from the broker.
-        store.move "$tmp-dir/patch"
-
-    bitstream := io.Reader trivial-old
-    patcher := Patcher bitstream null
-    patch-writer := PatchWriter
-    if not patcher.patch patch-writer: return
-    // Build the old bits and check that we get the correct hash.
-    old := patch-writer.buffer.bytes
-    if old.size < patch-writer.size: old += ByteArray (patch-writer.size - old.size)
-    sha := sha256.Sha256
-    sha.add old
-    if patch.from_ != sha.get: return
-
-    diff-id := id_ --from=patch.from_ --to=patch.to_
-    cache-key = "$connected-broker.id/$organization-id/patches/$diff-id"
-    cache_.get cache-key: | store/cache.FileStore |
-      // Build the diff and verify that we can apply it and get the
-      // correct hash out before uploading it.
-      diff := build-diff-patch old patch.bits_
-      if patch.to_ != (compute-applied-hash_ diff old): return
-      diff-size-bytes := diff.reduce --initial=0: | size chunk | size + chunk.size
-      diff-size := diff-size-bytes > 4096
-          ? "$((diff-size-bytes + 1023) / 1024) KB"
-          : "$diff-size-bytes B"
-      ui_.info "Uploading patch $(base64.encode patch.to_ --url-mode) ($diff-size)."
-      connected-broker.upload-firmware diff
-          --organization-id=organization-id
-          --firmware-id=diff-id
-      store.save-via-writer: | writer/io.Writer |
-        diff.do: writer.write it
-
-  static id_ --from/ByteArray?=null --to/ByteArray -> string:
-    folder := base64.encode to --url-mode
-    entry := from ? (base64.encode from --url-mode) : "none"
-    return "$folder/$entry"
-
-  static compute-applied-hash_ diff/List old/ByteArray -> ByteArray?:
-    combined := diff.reduce --initial=#[]: | acc chunk | acc + chunk
-    bitstream := io.Reader combined
-    patcher := Patcher bitstream old
-    writer := PatchWriter
-    if not patcher.patch writer: return null
-    sha := sha256.Sha256
-    sha.add writer.buffer.bytes
-    return sha.get
-
-is-same-broker broker/string identity/Map tmp/string assets-path/string sdk/Sdk -> bool:
-  broker-path := "$tmp/broker.json"
-  sdk.run-assets-tool [
-    "-e", assets-path,
-    "get", "--format=tison",
-    "-o", broker-path,
-    "broker"
-  ]
-  // TODO(kasper): This is pretty crappy.
-  x := ((json.stringify identity["broker"]) + "\n").to-byte-array
-  y := (file.read-content broker-path)
-  return x == y
+  list-sdk-service-versions -> List
+      --organization-id/uuid.Uuid
+      --sdk-version/string?
+      --service-version/string?:
+    return connected-artemis-server_.list-sdk-service-versions
+        --organization-id=organization-id
+        --sdk-version=sdk-version
+        --service-version=service-version

--- a/src/cli/broker.toit
+++ b/src/cli/broker.toit
@@ -1,0 +1,950 @@
+// Copyright (C) 2024 Toitware ApS. All rights reserved.
+
+import crypto.sha256
+import host.file
+import host.os
+import io
+import net
+import uuid
+
+import encoding.base64
+import encoding.ubjson
+
+import .artemis
+import .cache
+import .config
+import .ui
+import .device
+import .pod
+import .pod-specification
+
+import .utils
+import .utils.patch-build show build-diff-patch build-trivial-patch
+import ..shared.utils.patch show Patcher PatchObserver
+
+import .brokers.broker
+import .firmware
+import .pod-registry
+import .program
+import .sdk
+import .server-config
+
+class UploadResult:
+  fleet-id/uuid.Uuid
+  id/uuid.Uuid
+  name/string
+  revision/int
+  tags/List
+  tag-errors/List
+
+  constructor --.fleet-id --.id --.name --.revision --.tags --.tag-errors:
+
+  to-json -> Map:
+    result := {
+      "fleet-id": "$fleet-id",
+      "id": "$id",
+      "name": name,
+      "revision": revision,
+      "tags": tags,
+    }
+    if not tag-errors.is-empty:
+      result["tag-errors"] = tag-errors
+    return result
+
+class PodBroker:
+  id/uuid.Uuid
+  name/string?
+  revision/int?
+  tags/List?
+
+  constructor --.id --.name --.revision --.tags:
+
+/**
+Manages devices that have an Artemis service running on them.
+*/
+class Broker:
+  fleet-id/uuid.Uuid
+  organization-id/uuid.Uuid
+  server-config/ServerConfig
+  config_/Config
+  cache_/Cache
+  ui_/Ui
+  network_/net.Client? := null
+  tmp-directory_/string
+
+  broker-connection__/BrokerCli? := null
+
+  constructor
+      --.fleet-id/uuid.Uuid
+      --.organization-id/uuid.Uuid
+      --.server-config
+      --config/Config
+      --cache/Cache
+      --ui/Ui
+      --tmp-directory/string:
+    config_ = config
+    cache_ = cache
+    ui_ = ui
+    tmp-directory_ = tmp-directory
+
+
+  /** Opens the network. */
+  connect-network_:
+    if network_: return
+    network_ = net.open
+
+  broker-connection_ -> BrokerCli:
+    if not broker-connection__:
+      broker-connection__ = BrokerCli server-config config_
+      broker-connection__.ensure-authenticated: | error-message |
+        ui_.abort "$error-message (broker)."
+    return broker-connection__
+
+  /**
+  Ensures that the broker is authenticated.
+  */
+  ensure-authenticated:
+    broker-connection_
+
+  /**
+  Closes the broker.
+
+  If the broker opened any connections, closes them as well.
+  */
+  close:
+    if broker-connection__:
+      broker-connection__.close
+      broker-connection__ = null
+    if network_:
+      network_.close
+      network_ = null
+
+  /**
+  Uploads the given $pod to the broker for the given $fleet-id in $organization-id.
+
+  Also uploads the trivial patches.
+  */
+  upload --pod/Pod --tags/List --force-tags/bool -> UploadResult:
+    pod.split: | manifest/Map parts/Map |
+      parts.do: | id/string content/ByteArray |
+        // Only upload if we don't have it in our cache.
+        key := "$POD-PARTS-PATH/$organization-id/$id"
+        cache_.get-file-path key: | store/FileStore |
+          broker-connection_.pod-registry-upload-pod-part content --part-id=id
+              --organization-id=organization-id
+          store.save content
+      key := "$POD-MANIFEST-PATH/$organization-id/$pod.id"
+      cache_.get-file-path key: | store/FileStore |
+        encoded := ubjson.encode manifest
+        broker-connection_.pod-registry-upload-pod-manifest encoded --pod-id=pod.id
+            --organization-id=organization-id
+        store.save encoded
+
+    description-ids := broker-connection_.pod-registry-descriptions
+        --fleet-id=fleet-id
+        --organization-id=organization-id
+        --names=[pod.name]
+        --create-if-absent
+
+    description-id := (description-ids[0] as PodRegistryDescription).id
+
+    broker-connection_.pod-registry-add
+        --pod-description-id=description-id
+        --pod-id=pod.id
+
+    is-existing-tag-error := : | error |
+      error is string and
+        (error.contains "duplicate key value" or error.contains "already exists")
+
+    tag-errors := []
+    tags.do: | tag/string |
+      force := force-tags or (tag == "latest")
+      exception := catch --unwind=(: not is-existing-tag-error.call it):
+        broker-connection_.pod-registry-tag-set
+            --pod-description-id=description-id
+            --pod-id=pod.id
+            --tag=tag
+            --force=force
+      if exception:
+        tag-errors.add "Tag '$tag' already exists for pod $pod.name."
+
+    registered-pods := broker-connection_.pod-registry-pods --fleet-id=fleet-id --pod-ids=[pod.id]
+    pod-entry/PodRegistryEntry := registered-pods[0]
+
+    sorted-uploaded-tags := pod-entry.tags.sort
+    return UploadResult
+        --fleet-id=fleet-id
+        --id=pod.id
+        --name=pod.name
+        --revision=pod-entry.revision
+        --tags=sorted-uploaded-tags
+        --tag-errors=tag-errors
+
+  upload_ --firmware-content/FirmwareContent:
+    firmware-content.trivial-patches.do:
+      upload-patch_ it
+
+  upload_ --firmware-content/FirmwareContent --organization-id/uuid.Uuid:
+    firmware-content.trivial-patches.do:
+      upload-patch_ it
+
+  /**
+  Uploads the given $patch to the server under the given $organization-id.
+  */
+  upload-patch_ patch/FirmwarePatch:
+    diff-and-upload_ patch
+
+  /**
+  Computes patches and uploads them to the broker.
+  */
+  diff-and-upload_ patch/FirmwarePatch -> none:
+    trivial-id := id_ --to=patch.to_
+    cache-key := "$broker-connection_.id/$organization-id/patches/$trivial-id"
+
+    // Unless it is already cached, always create/upload the trivial one.
+    cache_.get cache-key: | store/FileStore |
+      trivial := build-trivial-patch patch.bits_
+      broker-connection_.upload-firmware trivial
+          --organization-id=organization-id
+          --firmware-id=trivial-id
+      store.save-via-writer: | writer/io.Writer |
+        trivial.do: writer.write it
+
+    if not patch.from_: return
+
+    // Attempt to fetch the old trivial patch and use it to construct
+    // the old bits so we can compute a diff from them.
+    old-id := id_ --to=patch.from_
+    cache-key = "$broker-connection_.id/$organization-id/patches/$old-id"
+    trivial-old := cache_.get cache-key: | store/FileStore |
+      downloaded := null
+      catch: downloaded = broker-connection_.download-firmware
+          --organization-id=organization-id
+          --id=old-id
+      if not downloaded: return
+      store.with-tmp-directory: | tmp-dir |
+        file.write-content downloaded --path="$tmp-dir/patch"
+        // TODO(florian): we don't have the chunk-size when downloading from the broker.
+        store.move "$tmp-dir/patch"
+
+    bitstream := io.Reader trivial-old
+    patcher := Patcher bitstream null
+    patch-writer := PatchWriter
+    if not patcher.patch patch-writer: return
+    // Build the old bits and check that we get the correct hash.
+    old := patch-writer.buffer.bytes
+    if old.size < patch-writer.size: old += ByteArray (patch-writer.size - old.size)
+    sha := sha256.Sha256
+    sha.add old
+    if patch.from_ != sha.get: return
+
+    diff-id := id_ --from=patch.from_ --to=patch.to_
+    cache-key = "$broker-connection_.id/$organization-id/patches/$diff-id"
+    cache_.get cache-key: | store/FileStore |
+      // Build the diff and verify that we can apply it and get the
+      // correct hash out before uploading it.
+      diff := build-diff-patch old patch.bits_
+      if patch.to_ != (compute-applied-hash_ diff old): return
+      diff-size-bytes := diff.reduce --initial=0: | size chunk | size + chunk.size
+      diff-size := diff-size-bytes > 4096
+          ? "$((diff-size-bytes + 1023) / 1024) KB"
+          : "$diff-size-bytes B"
+      ui_.info "Uploading patch $(base64.encode patch.to_ --url-mode) ($diff-size)."
+      broker-connection_.upload-firmware diff
+          --organization-id=organization-id
+          --firmware-id=diff-id
+      store.save-via-writer: | writer/io.Writer |
+        diff.do: writer.write it
+
+  static id_ --from/ByteArray?=null --to/ByteArray -> string:
+    folder := base64.encode to --url-mode
+    entry := from ? (base64.encode from --url-mode) : "none"
+    return "$folder/$entry"
+
+  static compute-applied-hash_ diff/List old/ByteArray -> ByteArray?:
+    combined := diff.reduce --initial=#[]: | acc chunk | acc + chunk
+    bitstream := io.Reader combined
+    patcher := Patcher bitstream old
+    writer := PatchWriter
+    if not patcher.patch writer: return null
+    sha := sha256.Sha256
+    sha.add writer.buffer.bytes
+    return sha.get
+
+  download --pod-id/uuid.Uuid -> Pod:
+    manifest-key := "$POD-MANIFEST-PATH/$organization-id/$pod-id"
+    encoded-manifest := cache_.get manifest-key: | store/FileStore |
+      bytes := broker-connection_.pod-registry-download-pod-manifest
+        --pod-id=pod-id
+        --organization-id=organization-id
+      store.save bytes
+    manifest := ubjson.decode encoded-manifest
+    return Pod.from-manifest
+        manifest
+        --tmp-directory=tmp-directory_
+        --download=: | part-id/string |
+          key := "$POD-PARTS-PATH/$organization-id/$part-id"
+          cache_.get key: | store/FileStore |
+            bytes := broker-connection_.pod-registry-download-pod-part
+                part-id
+                --organization-id=organization-id
+            store.save bytes
+
+  list-pods --names/List -> Map:
+    descriptions := ?
+    if names.is-empty:
+      descriptions = broker-connection_.pod-registry-descriptions --fleet-id=fleet-id
+    else:
+      descriptions = broker-connection_.pod-registry-descriptions
+          --fleet-id=fleet-id
+          --organization-id=organization-id
+          --names=names
+          --no-create-if-absent
+    result := {:}
+    descriptions.do: | description/PodRegistryDescription |
+      pods := broker-connection_.pod-registry-pods --pod-description-id=description.id
+      result[description] = pods
+    return result
+
+  delete --description-names/List:
+    descriptions := broker-connection_.pod-registry-descriptions
+        --fleet-id=fleet-id
+        --organization-id=organization-id
+        --names=description-names
+        --no-create-if-absent
+    unknown-pod-descriptions := []
+    description-names.do: | name/string |
+      was-found := descriptions.any: | description/PodRegistryDescription |
+        description.name == name
+      if not was-found: unknown-pod-descriptions.add name
+    if not unknown-pod-descriptions.is-empty:
+      if unknown-pod-descriptions.size == 1:
+        ui_.abort "Unknown pod $(unknown-pod-descriptions[0])."
+      else:
+        ui_.abort "Unknown pods $(unknown-pod-descriptions.join ", ")."
+    broker-connection_.pod-registry-descriptions-delete
+        --fleet-id=fleet-id
+        --description-ids=descriptions.map: it.id
+
+  delete --pod-references/List:
+    pod-ids := get-pod-ids pod-references
+    delete --pod-ids=pod-ids
+
+  delete --pod-ids/List:
+    broker-connection_.pod-registry-delete
+        --fleet-id=fleet-id
+        --pod-ids=pod-ids
+
+  get-pod-ids references/List -> List:
+    references.do: | reference/PodReference |
+      if not reference.id:
+        if not reference.name:
+          throw "Either id or name must be specified: $reference"
+        if not reference.tag and not reference.revision:
+          throw "Either tag or revision must be specified: $reference"
+
+    missing-ids := references.filter: | reference/PodReference |
+      not reference.id
+    pod-ids-response := broker-connection_.pod-registry-pod-ids
+        --fleet-id=fleet-id
+        --references=missing-ids
+
+    has-errors := false
+    result := references.map: | reference/PodReference |
+      if reference.id: continue.map reference.id
+      resolved := pod-ids-response.get reference
+      if not resolved:
+        has-errors = true
+        if reference.tag:
+          ui_.error "No pod with name $reference.name and tag $reference.tag in the fleet."
+        else:
+          ui_.error "No pod with name $reference.name and revision $reference.revision in the fleet."
+      resolved
+    if has-errors: ui_.abort
+    return result
+
+  pod pod-id/uuid.Uuid -> PodBroker:
+    pod-entry := broker-connection_.pod-registry-pods
+        --fleet-id=fleet-id
+        --pod-ids=[pod-id]
+    if not pod-entry.is-empty:
+      description-id := pod-entry[0].pod-description-id
+      description := broker-connection_.pod-registry-descriptions --ids=[description-id]
+      if not description.is-empty:
+        return PodBroker --id=pod-id --name=description[0].name --revision=pod-entry[0].revision --tags=pod-entry[0].tags
+
+    return PodBroker --id=pod-id --name=null --revision=null --tags=null
+
+  get-pod-id reference/PodReference -> uuid.Uuid:
+    return (get-pod-ids [reference])[0]
+
+  get-pod-id --name/string --tag/string? --revision/int? -> uuid.Uuid:
+    return get-pod-id (PodReference --name=name --tag=tag --revision=revision)
+
+  pod-exists reference/PodReference -> bool:
+    pod-id := get-pod-id reference
+    pod-entry := broker-connection_.pod-registry-pods
+        --fleet-id=fleet-id
+        --pod-ids=[pod-id]
+    return not pod-entry.is-empty
+
+  /**
+  Fetches the device details for the given device ids.
+  Returns a map from id to $DeviceDetailed.
+  */
+  get-devices --device-ids/List -> Map:
+    return broker-connection_.get-devices --device-ids=device-ids
+
+  update --device-id/uuid.Uuid --pod/Pod --base-firmwares/List=[]:
+    update-bulk_ --devices=[device-for --id=device-id] --pods=[pod] --base-firmwares=base-firmwares
+
+  /**
+  Rolls out.
+  */
+  roll-out -> none
+      --devices/List  // Of DeviceDetailed.
+      --pods/List
+      --diff-bases/List  // Of Pod
+  :
+
+    base-patches := {:}
+
+    base-firmwares := diff-bases.map: | diff-base/Pod |
+      FirmwareContent.from-envelope diff-base.envelope-path --cache=cache_
+
+    base-firmwares.do: | content/FirmwareContent |
+      trivial-patches := extract-trivial-patches_ content
+      trivial-patches.do: | _ patch/FirmwarePatch |
+        upload-patch_ patch
+
+    update-bulk_
+        --devices=devices
+        --pods=pods
+        --base-firmwares=base-firmwares
+  /**
+  Extracts the trivial patches from the given $firmware-content.
+
+  Returns a mapping from patch-id (as used when diffing to the part) and
+    the patch itself.
+  */
+  extract-trivial-patches_ firmware-content/FirmwareContent -> Map:
+    result := {:}
+    firmware-content.trivial-patches.do: | patch/FirmwarePatch |
+      patch-id := id_ --to=patch.to_
+      result[patch-id] = patch
+    return result
+
+  /**
+  Update the given $devices.
+
+  The lists $devices and $pods must have the same size.
+
+  The $devices list must contain $DeviceDetailed objects.
+  The $pods list must contain $Pod objects.
+
+  Uploads the $pods if they it haven't been uploaded yet.
+  For each device computes upgrade-patches and uploads them if needed.
+
+  If a device has no known current state, then uses the $base-firmwares
+    (a list of $FirmwareContent) for diff-based patches. If the list
+    is empty, the device must upgrade using trivial patches.
+
+  Trivial patches are always uploaded (as part of the pod upload).
+  */
+  update-bulk_ --devices/List --pods/List --base-firmwares/List=[] -> none:
+    unconfigured-cache := {:}
+
+    goals := []
+    devices.size.repeat: | i |
+      device := devices[i]
+      pod := pods[i]
+      unconfigured := unconfigured-cache.get pod.id --init=:
+        FirmwareContent.from-envelope pod.envelope-path --cache=cache_
+
+      goal := prepare-update-device_
+          --device=device
+          --pod=pod
+          --unconfigured-content=unconfigured
+          --base-firmwares=base-firmwares
+      goals.add goal
+
+    broker-connection_.update-goals
+        --device-ids=devices.map: it.id
+        --goals=goals
+
+  /**
+  Prepares the update for the given $device.
+
+  Computes the patch and uploads it.
+  Returns the new goal state for the device.
+  */
+  prepare-update-device_ --device/DeviceDetailed --pod/Pod --unconfigured-content/FirmwareContent --base-firmwares/List -> Map:
+    device-id := device.id
+    upload_ --firmware-content=unconfigured-content
+
+    known-encoded-firmwares := {}
+    [
+      device.goal,
+      device.reported-state-firmware,
+      device.reported-state-current,
+      device.reported-state-goal,
+    ].do: | state/Map? |
+      // The device might be running this firmware.
+      if state: known-encoded-firmwares.add state["firmware"]
+
+    upgrade-from := []
+    if known-encoded-firmwares.is-empty:
+      if base-firmwares.is-empty:
+        ui_.warning "Firmware of device '$device-id' is unknown. Upgrade might not use patches."
+      else:
+        upgrade-from = base-firmwares
+    else:
+      known-encoded-firmwares.do: | encoded/string |
+        old-firmware := Firmware.encoded encoded
+        old-device-map := old-firmware.device-specific "artemis.device"
+        old-device-id := uuid.parse old-device-map["device_id"]
+        if device-id != old-device-id:
+          ui_.abort "The device id of the firmware image ($old-device-id) does not match the given device id ($device-id)."
+        upgrade-from.add old-firmware.content
+
+    result := compute-updated-goal_
+        --device=device
+        --upgrade-from=upgrade-from
+        --pod=pod
+        --unconfigured-content=unconfigured-content
+    return result
+
+  /**
+  Computes the goal for the given $device, upgrading from the $upgrade-from
+    firmware content entries to the firmware image given by the $pod.
+
+  Uploads the patches to the broker in the same organization as the $device.
+
+  The returned goal state will instruct the device to download the firmware image
+    and install it.
+  */
+  compute-updated-goal_ --device/Device --upgrade-from/List --pod/Pod --unconfigured-content/FirmwareContent -> Map:
+    // Compute the patches and upload them.
+    ui_.info "Computing and uploading patches for $device.id."
+    upgrade-to := Firmware --pod=pod --device=device --cache=cache_ --unconfigured-content=unconfigured-content
+    upgrade-from.do: | old-firmware-content/FirmwareContent |
+      patches := upgrade-to.content.patches old-firmware-content
+      patches.do: diff-and-upload_ it --organization-id=device.organization-id
+
+    // Build the updated goal and return it.
+    sdk := get-sdk pod.sdk-version --cache=cache_
+    goal := (pod.device-config --sdk=sdk).copy
+    goal["firmware"] = upgrade-to.encoded
+    return goal
+
+  /**
+  Computes patches and uploads them to the broker.
+  */
+  diff-and-upload_ patch/FirmwarePatch --organization-id/uuid.Uuid -> none:
+    trivial-id := id_ --to=patch.to_
+    cache-key := "$broker-connection_.id/$organization-id/patches/$trivial-id"
+
+    // Unless it is already cached, always create/upload the trivial one.
+    cache_.get cache-key: | store/FileStore |
+      trivial := build-trivial-patch patch.bits_
+      broker-connection_.upload-firmware trivial
+          --organization-id=organization-id
+          --firmware-id=trivial-id
+      store.save-via-writer: | writer/io.Writer |
+        trivial.do: writer.write it
+
+    if not patch.from_: return
+
+    // Attempt to fetch the old trivial patch and use it to construct
+    // the old bits so we can compute a diff from them.
+    old-id := id_ --to=patch.from_
+    cache-key = "$broker-connection_.id/$organization-id/patches/$old-id"
+    trivial-old := cache_.get cache-key: | store/FileStore |
+      downloaded := null
+      catch: downloaded = broker-connection_.download-firmware
+          --organization-id=organization-id
+          --id=old-id
+      if not downloaded: return
+      store.with-tmp-directory: | tmp-dir |
+        file.write-content downloaded --path="$tmp-dir/patch"
+        // TODO(florian): we don't have the chunk-size when downloading from the broker.
+        store.move "$tmp-dir/patch"
+
+    bitstream := io.Reader trivial-old
+    patcher := Patcher bitstream null
+    patch-writer := PatchWriter
+    if not patcher.patch patch-writer: return
+    // Build the old bits and check that we get the correct hash.
+    old := patch-writer.buffer.bytes
+    if old.size < patch-writer.size: old += ByteArray (patch-writer.size - old.size)
+    sha := sha256.Sha256
+    sha.add old
+    if patch.from_ != sha.get: return
+
+    diff-id := id_ --from=patch.from_ --to=patch.to_
+    cache-key = "$broker-connection_.id/$organization-id/patches/$diff-id"
+    cache_.get cache-key: | store/FileStore |
+      // Build the diff and verify that we can apply it and get the
+      // correct hash out before uploading it.
+      diff := build-diff-patch old patch.bits_
+      if patch.to_ != (compute-applied-hash_ diff old): return
+      diff-size-bytes := diff.reduce --initial=0: | size chunk | size + chunk.size
+      diff-size := diff-size-bytes > 4096
+          ? "$((diff-size-bytes + 1023) / 1024) KB"
+          : "$diff-size-bytes B"
+      ui_.info "Uploading patch $(base64.encode patch.to_ --url-mode) ($diff-size)."
+      broker-connection_.upload-firmware diff
+          --organization-id=organization-id
+          --firmware-id=diff-id
+      store.save-via-writer: | writer/io.Writer |
+        diff.do: writer.write it
+
+  get-goal-request-events --device-ids/List --limit/int -> Map:
+    return broker-connection_.get-events
+        --device-ids=device-ids
+        --limit=limit
+        --types=["get-goal"]
+
+  get-last-events --device-ids/List -> Map:
+    return broker-connection_.get-events
+        --device-ids=device-ids
+        --limit=1
+
+  get-events --device-ids/List --limit/int --types/List? -> Map:
+    return broker-connection_.get-events
+        --device-ids=device-ids
+        --limit=limit
+        --types=types
+
+  /**
+  Fetches the pod information for the given $pod-ids.
+
+  Returns a map from pod id to $PodRegistryEntry.
+  */
+  get-pod-registry-entry-map --pod-ids/List -> Map:
+    pod-id-entries := broker-connection_.pod-registry-pods
+        --fleet-id=fleet-id
+        --pod-ids=pod-ids
+    pod-entry-map := {:}
+    pod-id-entries.do: | entry/PodRegistryEntry |
+      pod-entry-map[entry.id] = entry
+    return pod-entry-map
+
+  /**
+  Returns a map from description-id to $PodRegistryDescription.
+
+  The given $pod-registry-entries must be a list of $PodRegistryEntry instances.
+  */
+  get-pod-descriptions --pod-registry-entries/List -> Map:
+    description-set := {}
+    description-set.add-all
+        (pod-registry-entries.map: | entry/PodRegistryEntry | entry.pod-description-id)
+    description-ids := []
+    description-ids.add-all description-set
+    descriptions := broker-connection_.pod-registry-descriptions --ids=description-ids
+    description-map := {:}
+    descriptions.do: | description/PodRegistryDescription |
+      description-map[description.id] = description
+    return description-map
+
+  notify-created --device-id/uuid.Uuid --state/Map -> none:
+    broker-connection_.notify-created --device-id=device-id --state=state
+
+  device-for --id/uuid.Uuid -> DeviceDetailed:
+    devices := broker-connection_.get-devices --device-ids=[id]
+    if devices.is-empty:
+      ui_.abort "Device '$id' not found."
+    return devices[id]
+
+  /**
+  Updates the goal state of the device with the given $device-id.
+
+  See $BrokerCli.update-goal.
+  */
+  update-goal_ --device-id/uuid.Uuid [block]:
+    broker-connection_.update-goal --device-id=device-id block
+
+  container-install -> none
+      --device-id/uuid.Uuid
+      --app-name/string
+      --application-path/string
+      --arguments/List?
+      --background/bool
+      --critical/bool
+      --triggers/List?:
+    update-goal_ --device-id=device-id: | device/DeviceDetailed |
+      current-state := device.reported-state-current or device.reported-state-firmware
+      if not current-state:
+        ui_.abort "Unknown device state."
+      firmware := Firmware.encoded current-state["firmware"]
+      sdk-version := firmware.sdk-version
+      sdk := get-sdk sdk-version --cache=cache_
+      program := CompiledProgram.application application-path --sdk=sdk
+      id := program.id
+
+      cache-id := application-image-cache-key id --broker-config=server-config
+      cache_.get-directory-path cache-id: | store/DirectoryStore |
+        store.with-tmp-directory: | tmp-dir |
+          // TODO(florian): do we want to rely on the cache, or should we
+          // do a check to see if the files are really uploaded?
+          broker-connection_.upload-image program.image32
+              --app-id=id
+              --organization-id=device.organization-id
+              --word-size=32
+          file.write-content program.image32 --path="$tmp-dir/image32.bin"
+          broker-connection_.upload-image program.image64
+              --organization-id=device.organization-id
+              --app-id=id
+              --word-size=64
+          file.write-content program.image64 --path="$tmp-dir/image64.bin"
+          store.move tmp-dir
+
+      if not device.goal and not device.reported-state-firmware:
+        throw "No known firmware information for device."
+      new-goal := device.goal or device.reported-state-firmware
+      ui_.info "Installing container '$app-name'."
+      apps := new-goal.get "apps" --if-absent=: {:}
+      apps[app-name] = build-container-description_
+          --id=id
+          --arguments=arguments
+          --background=background
+          --critical=critical
+          --runlevel=null  // TODO(florian): should we allow to set the runlevel?
+          --triggers=triggers
+      new-goal["apps"] = apps
+      new-goal
+
+  container-uninstall --device-id/uuid.Uuid --app-name/string --force/bool:
+    update-goal_ --device-id=device-id: | device/DeviceDetailed |
+      if not device.goal and not device.reported-state-firmware:
+        throw "No known firmware information for device."
+      new-goal := device.goal or device.reported-state-firmware
+      connections/List := new-goal.get "connections" --if-absent=: []
+      is-required := false
+      connections.do:
+        required := it.get "requires" --if-absent=: []
+        if required.contains app-name:
+          is-required = true
+      if is-required and not force:
+        ui_.abort "Container '$app-name' is required by a connection."
+      apps := new-goal.get "apps"
+      if apps:
+        if not apps.contains app-name and not force:
+          ui_.abort "Container '$app-name' is not installed."
+        else:
+          ui_.info "Uninstalling container '$app-name'."
+          apps.remove app-name
+      new-goal
+
+  config-set-max-offline --device-id/uuid.Uuid --max-offline-seconds/int:
+    update-goal_ --device-id=device-id: | device/DeviceDetailed |
+      if not device.goal and not device.reported-state-firmware:
+        throw "No known firmware information for device."
+      new-goal := device.goal or device.reported-state-firmware
+      ui_.info "Setting max-offline to $(Duration --s=max-offline-seconds)."
+      if max-offline-seconds > 0:
+        new-goal["max-offline"] = max-offline-seconds
+      else:
+        new-goal.remove "max-offline"
+      new-goal
+
+  static has-implicit-network_ chip-family/string -> bool:
+    return chip-family == "host"
+
+  /**
+  Customizes a generic Toit envelope with the given $specification.
+    Also installs the Artemis service.
+
+  The image is ready to be flashed together with the identity file.
+  */
+  customize-envelope
+      --organization-id/uuid.Uuid
+      --specification/PodSpecification
+      --artemis/Artemis
+      --output-path/string:
+    service-version := specification.artemis-version
+    sdk-version := specification.sdk-version
+
+    checked := false
+    // We try to check the sdk and service versions as soon as possible to
+    // avoid downloading expensive assets.
+    check-sdk-service-version := :
+      if not checked and sdk-version:
+        artemis.check-is-supported-version_
+            --organization-id=organization-id
+            --sdk=sdk-version
+            --service=service-version
+        checked = true
+
+    check-sdk-service-version.call
+
+    envelope-path := get-envelope
+        --specification=specification
+        --cache=cache_
+
+    // Extract the sdk version from the envelope.
+    envelope := file.read-content envelope-path
+    envelope-sdk-version := Sdk.get-sdk-version-from --envelope=envelope
+    envelope-chip-family := Sdk.get-chip-family-from --envelope=envelope
+    if sdk-version:
+      if sdk-version != envelope-sdk-version:
+        if not (is-dev-setup and os.env.get "DEV_TOIT_REPO_PATH"):
+          ui_.abort "The envelope uses SDK version '$envelope-sdk-version', but '$sdk-version' was requested."
+    else:
+      sdk-version = envelope-sdk-version
+      check-sdk-service-version.call
+    envelope-word-bit-size := Sdk.get-word-bit-size-from --envelope=envelope
+
+    sdk := get-sdk sdk-version --cache=cache_
+
+    copy-file --source=envelope-path --target=output-path
+
+    device-config := {
+      "sdk-version": sdk-version,
+    }
+
+    // Add the max-offline setting if is non-zero. The device service
+    // handles the absence of the max-offline setting differently, so
+    // we cannot just add zero seconds to the config. This matches what
+    // we do in $config_set_max_offline.
+    max-offline-seconds := specification.max-offline-seconds
+    if max-offline-seconds > 0: device-config["max-offline"] = max-offline-seconds
+
+    if specification.connections.is-empty and not has-implicit-network_ envelope-chip-family:
+      ui_.warning "No network connections configured."
+    connections := specification.connections.map: | connection/ConnectionInfo |
+      connection.to-json
+    device-config["connections"] = connections
+
+    // Create the assets for the Artemis service.
+    // TODO(florian): share this code with the identity creation code.
+    der-certificates := {:}
+    broker-json := server-config-to-service-json server-config der-certificates
+    artemis-json := server-config-to-service-json artemis.server-config der-certificates
+
+    with-tmp-directory: | tmp-dir |
+      // Store the containers in the envelope.
+      specification.containers.do: | name/string container/Container |
+        snapshot-path := "$tmp-dir/$(name).snapshot"
+        container.build-snapshot
+            --relative-to=specification.relative-to
+            --sdk=sdk
+            --output-path=snapshot-path
+            --cache=cache_
+            --ui=ui_
+
+        // Build the assets from the defines (if any).
+        assets-path/string? := null
+        if container.defines:
+          assets-path = "$tmp-dir/$(name).assets"
+          assets := {
+            "artemis.defines": {
+              "format": "tison",
+              "json": container.defines
+            }
+          }
+          sdk.assets-create --output-path=assets-path assets
+
+        sdk.firmware-add-container name
+            --envelope=output-path
+            --assets=assets-path
+            --program-path=snapshot-path
+            --trigger="none"
+
+        // TODO(kasper): Avoid computing the image id here. We should
+        // be able to get it from the firmware tool.
+        sha := sha256.Sha256
+        snapshot-uuid-string := extract-id-from-snapshot snapshot-path
+        sha.add (uuid.parse snapshot-uuid-string).to-byte-array
+        if assets-path:
+          sha.add (file.read-content assets-path)
+        id := uuid.Uuid sha.get[..uuid.SIZE]
+
+        triggers := container.triggers
+        if not container.is-critical and not triggers:
+          // Non-critical containers default to having a boot trigger.
+          triggers = [BootTrigger]
+        apps := device-config.get "apps" --init=:{:}
+        apps[name] = build-container-description_
+            --id=id
+            --arguments=container.arguments
+            --background=container.is-background
+            --critical=container.is-critical
+            --runlevel=container.runlevel
+            --triggers=triggers
+        ui_.info "Added container '$name' to envelope."
+
+      artemis-assets := {
+        // TODO(florian): share the keys of the assets with the Artemis service.
+        "broker": {
+          "format": "tison",
+          "json": broker-json,
+        },
+        "artemis.broker": {
+          "format": "tison",
+          "json": artemis-json,
+        },
+      }
+      der-certificates.do: | name/string value/ByteArray |
+        // The 'server_config_to_service_json' function puts the certificates
+        // into their own namespace.
+        assert: name.starts-with "certificate-"
+        artemis-assets[name] = {
+          "format": "binary",
+          "blob": value,
+        }
+
+      artemis-assets["device-config"] = {
+        "format": "ubjson",
+        "json": device-config,
+      }
+
+      artemis-assets-path := "$tmp-dir/artemis.assets"
+      sdk.assets-create --output-path=artemis-assets-path artemis-assets
+
+      // Get the prebuilt Artemis service.
+      artemis-service-image-path := artemis.get-service-image-path
+          --organization-id=organization-id
+          --chip-family=envelope-chip-family
+          --word-size=envelope-word-bit-size
+          --sdk=sdk-version
+          --service=service-version
+
+      sdk.firmware-add-container "artemis"
+          --envelope=output-path
+          --assets=artemis-assets-path
+          --program-path=artemis-service-image-path
+          --trigger="boot"
+          --critical
+
+    // For convenience save all snapshots in the user's cache.
+    cache-snapshots --envelope-path=output-path --cache=cache_
+
+  /**
+  Builds a container description as needed for a "container" entry in the device state.
+  */
+  static build-container-description_ -> Map
+      --id/uuid.Uuid
+      --arguments/List?
+      --background/bool?
+      --critical/bool?
+      --runlevel/int?
+      --triggers/List?:
+    result := {
+      "id": id.stringify,
+    }
+    if arguments and not arguments.is-empty:
+      result["arguments"] = arguments
+    if background:
+      result["background"] = 1
+    if critical:
+      result["critical"] = 1
+    if runlevel:
+      result["runlevel"] = runlevel
+    if triggers and not triggers.is-empty:
+      trigger-map := {:}
+      triggers.do: | trigger/Trigger |
+        assert: not trigger-map.contains trigger.type
+        trigger-map[trigger.type] = trigger.json-value
+      result["triggers"] = trigger-map
+    return result

--- a/src/cli/cmds/device-container.toit
+++ b/src/cli/cmds/device-container.toit
@@ -128,7 +128,7 @@ install-container parsed/cli.Parsed config/Config cache/Cache ui/Ui:
     // Non-critical containers get a boot and an install trigger by default.
     triggers = [pod-specification.BootTrigger, pod-specification.InstallTrigger]
 
-  with-device parsed config cache ui: | device/DeviceFleet _ fleet/FleetWithDevices |
+  with-device parsed config cache ui: | device/DeviceFleet fleet/FleetWithDevices |
     fleet.broker.container-install
         --device-id=device.id
         --app-name=container-name
@@ -143,6 +143,6 @@ uninstall-container parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   container-name := parsed["name"]
   force := parsed["force"]
 
-  with-device parsed config cache ui: | device/DeviceFleet _ fleet/FleetWithDevices |
+  with-device parsed config cache ui: | device/DeviceFleet fleet/FleetWithDevices |
     fleet.broker.container-uninstall --device-id=device.id --app-name=container-name --force=force
     ui.info "Request sent to broker. Container will be uninstalled when device synchronizes."

--- a/src/cli/cmds/device-container.toit
+++ b/src/cli/cmds/device-container.toit
@@ -128,8 +128,8 @@ install-container parsed/cli.Parsed config/Config cache/Cache ui/Ui:
     // Non-critical containers get a boot and an install trigger by default.
     triggers = [pod-specification.BootTrigger, pod-specification.InstallTrigger]
 
-  with-device parsed config cache ui: | device/DeviceFleet artemis/Artemis _ |
-    artemis.container-install
+  with-device parsed config cache ui: | device/DeviceFleet _ fleet/FleetWithDevices |
+    fleet.broker.container-install
         --device-id=device.id
         --app-name=container-name
         --arguments=arguments
@@ -143,6 +143,6 @@ uninstall-container parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   container-name := parsed["name"]
   force := parsed["force"]
 
-  with-device parsed config cache ui: | device/DeviceFleet artemis/Artemis _ |
-    artemis.container-uninstall --device-id=device.id --app-name=container-name --force=force
+  with-device parsed config cache ui: | device/DeviceFleet _ fleet/FleetWithDevices |
+    fleet.broker.container-uninstall --device-id=device.id --app-name=container-name --force=force
     ui.info "Request sent to broker. Container will be uninstalled when device synchronizes."

--- a/src/cli/cmds/fleet.toit
+++ b/src/cli/cmds/fleet.toit
@@ -521,7 +521,7 @@ roll-out parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   with-devices-fleet parsed config cache ui: | fleet/FleetWithDevices |
     pod-diff-bases := diff-bases.map: | file-or-ref/string |
       if file.is-file file-or-ref:
-        Pod.parse file-or-ref --tmp-directory=fleet.artemis_.tmp-directory --ui=ui
+        Pod.parse file-or-ref --tmp-directory=fleet.artemis.tmp-directory --ui=ui
       else:
         fleet.download (PodReference.parse file-or-ref --ui=ui)
     fleet.roll-out --diff-bases=pod-diff-bases
@@ -543,18 +543,17 @@ add-existing-device parsed/cli.Parsed config/Config cache/Cache ui/Ui:
     if not fleet.has-group group:
       ui.abort "Group '$group' not found."
 
-    with-artemis parsed config cache ui: | artemis/Artemis |
-      broker := artemis.connected-broker
-      devices := broker.get-devices --device-ids=[device-id]
-      if devices.is-empty:
-        ui.abort "Device $device-id not found."
+    broker := fleet.broker
+    devices := broker.get-devices --device-ids=[device-id]
+    if devices.is-empty:
+      ui.abort "Device $device-id not found."
 
-      device/DeviceDetailed := devices[device-id]
-      if device.organization-id != fleet.organization-id:
-        ui.abort "Device $device-id is not in the same organization as the fleet."
+    device/DeviceDetailed := devices[device-id]
+    if device.organization-id != fleet.organization-id:
+      ui.abort "Device $device-id is not in the same organization as the fleet."
 
-      fleet.add-device --device-id=device.id --group=group --name=name --aliases=aliases
-      ui.info "Added device $device-id to fleet."
+    fleet.add-device --device-id=device.id --group=group --name=name --aliases=aliases
+    ui.info "Added device $device-id to fleet."
 
 group-list parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   with-devices-fleet parsed config cache ui: | fleet/FleetWithDevices |

--- a/src/cli/cmds/pod.toit
+++ b/src/cli/cmds/pod.toit
@@ -218,12 +218,14 @@ create-pod parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   output := parsed["output"]
 
   with-pod-fleet parsed config cache ui: | fleet/Fleet |
-    artemis := fleet.artemis_
+    artemis := fleet.artemis
+    broker := fleet.broker
     pod := Pod.from-specification
         --organization-id=fleet.organization-id
         --path=specification-path
         --ui=ui
         --artemis=artemis
+        --broker=broker
     pod.write output --ui=ui
 
 upload parsed/cli.Parsed config/Config cache/Cache ui/Ui:
@@ -243,11 +245,13 @@ upload parsed/cli.Parsed config/Config cache/Cache ui/Ui:
     tags.add "latest"
 
   with-pod-fleet parsed config cache ui: | fleet/Fleet |
-    artemis := fleet.artemis_
+    artemis := fleet.artemis
+    broker := fleet.broker
     pod-paths.do: | pod-path/string |
       pod := Pod.from-file pod-path
           --organization-id=fleet.organization-id
           --artemis=artemis
+          --broker=broker
           --ui=ui
       upload-result := fleet.upload --pod=pod --tags=tags --force-tags=force
       if ui.wants-structured-result:

--- a/src/cli/cmds/sdk.toit
+++ b/src/cli/cmds/sdk.toit
@@ -44,8 +44,8 @@ list-sdks parsed/cli.Parsed config/Config cache/Cache ui/Ui:
   service-version := parsed["service-version"]
 
   with-pod-fleet parsed config cache ui: | fleet/Fleet |
-    artemis := fleet.artemis_
-    versions/List := artemis.connected-artemis-server.list-sdk-service-versions
+    artemis := fleet.artemis
+    versions/List := artemis.list-sdk-service-versions
         --organization-id=fleet.organization-id
         --sdk-version=sdk-version
         --service-version=service-version

--- a/src/cli/cmds/utils_.toit
+++ b/src/cli/cmds/utils_.toit
@@ -12,7 +12,6 @@ import ..server-config
 import ..utils
 
 with-artemis parsed/cli.Parsed config/Config cache/Cache ui/Ui [block]:
-  broker-config := get-server-from-config config CONFIG-BROKER-DEFAULT-KEY
   artemis-config := get-server-from-config config CONFIG-ARTEMIS-DEFAULT-KEY
 
   with-tmp-directory: | tmp-directory/string |
@@ -21,8 +20,7 @@ with-artemis parsed/cli.Parsed config/Config cache/Cache ui/Ui [block]:
         --cache=cache
         --ui=ui
         --tmp-directory=tmp-directory
-        --broker-config=broker-config
-        --artemis-config=artemis-config
+        --server-config=artemis-config
     try:
       block.call artemis
     finally:
@@ -44,14 +42,24 @@ with-devices-fleet parsed/cli.Parsed config/Config cache/Cache ui/Ui [block]:
   fleet-root := compute-fleet-root-or-ref parsed config ui
 
   with-artemis parsed config cache ui: | artemis/Artemis |
-    fleet := FleetWithDevices fleet-root artemis --ui=ui --cache=cache --config=config
+    broker-config := get-server-from-config config CONFIG-BROKER-DEFAULT-KEY
+    fleet := FleetWithDevices fleet-root artemis
+        --broker-config=broker-config
+        --ui=ui
+        --cache=cache
+        --config=config
     block.call fleet
 
 with-pod-fleet parsed/cli.Parsed config/Config cache/Cache ui/Ui [block]:
   fleet-root-or-ref := compute-fleet-root-or-ref parsed config ui
 
   with-artemis parsed config cache ui: | artemis/Artemis |
-    fleet := Fleet fleet-root-or-ref artemis --ui=ui --cache=cache --config=config
+    broker-config := get-server-from-config config CONFIG-BROKER-DEFAULT-KEY
+    fleet := Fleet fleet-root-or-ref artemis
+        --broker-config=broker-config
+        --ui=ui
+        --cache=cache
+        --config=config
     block.call fleet
 
 compute-fleet-root-or-ref parsed/cli.Parsed config/Config ui/Ui -> string:

--- a/src/cli/fleet.toit
+++ b/src/cli/fleet.toit
@@ -290,6 +290,7 @@ class Fleet:
   */
   upload --pod/Pod --tags/List --force-tags/bool -> UploadResult:
     ui_.info "Uploading pod. This may take a while."
+
     return broker.upload
         --pod=pod
         --tags=tags

--- a/src/cli/pod.toit
+++ b/src/cli/pod.toit
@@ -286,7 +286,6 @@ class Pod:
 
     return firmware.device-specific-data
 
-
   static is-same-broker broker/string identity/Map tmp/string assets-path/string sdk/Sdk -> bool:
     broker-path := "$tmp/broker.json"
     sdk.run-assets-tool [


### PR DESCRIPTION
Shuffle code around.
No functional changes.

* Create a new `Broker` in broker.toit which is responsible for all the work that is related to things that end up on the broker. This includes roll-outs, ...
* The `Fleet` is now more limited to device management in the fleet, although it still has forwarders to the broker.
* The broker is created in the constructor of the Fleet. This means that we can now have a broker per fleet, instead of having a global one.
* Artemis, too, has been trimmed to only deal with things that are relevant to the Artemis server.
