### PR TITLE
Return the default broker.

### DIFF
--- a/src/cli/server-config.toit
+++ b/src/cli/server-config.toit
@@ -32,7 +32,7 @@ get-server-from-config config/Config ui/Ui --key/string -> ServerConfig?:
     return DEFAULT-ARTEMIS-SERVER-CONFIG
 
   if not server-name:
-    if key == CONFIG-ARTEMIS-DEFAULT-KEY:
+    if key == CONFIG-ARTEMIS-DEFAULT-KEY or key == CONFIG-BROKER-DEFAULT-KEY:
       return DEFAULT-ARTEMIS-SERVER-CONFIG
     return null
 


### PR DESCRIPTION
We were hitting a null-pointer exception if the config file had servers configured, but had no broker set.