### PR TITLE
Convert Supabase server configs to http on the host.

### DIFF
--- a/src/service/brokers/broker.toit
+++ b/src/service/brokers/broker.toit
@@ -67,27 +67,7 @@ An interface to communicate with the CLI through a broker.
 */
 interface BrokerService:
   constructor logger/log.Logger server-config/ServerConfig:
-    if server-config is ServerConfigSupabase:
-      supabase-config := server-config as ServerConfigSupabase
-      host := supabase-config.host
-      port := null
-      colon-pos := host.index-of ":"
-      if colon-pos >= 0:
-        port = int.parse host[colon-pos + 1..]
-        host = host[..colon-pos]
-      der := supabase-config.root-certificate-der
-      http-config := ServerConfigHttp
-          server-config.name
-          --host=host
-          --port=port
-          --path="/functions/v1/b"  // TODO(florian): get the path from the config.
-          --poll-interval=supabase-config.poll-interval
-          --root-certificate-names=null
-          --root-certificate-ders=der ? [der] : null
-          --admin-headers=null
-          --device-headers=null
-      return BrokerServiceHttp logger http-config
-    else if server-config is ServerConfigHttp:
+    if server-config is ServerConfigHttp:
       return BrokerServiceHttp logger (server-config as ServerConfigHttp)
     else:
       throw "unknown broker $server-config"

--- a/src/shared/server-config.toit
+++ b/src/shared/server-config.toit
@@ -179,7 +179,26 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
     return result
 
   to-service-json [--der-serializer] -> Map:
-    return to-json --der-serializer=der-serializer
+    // The device only knows about HTTP-configs. Convert this Supabase config into
+    // an HTTP one.
+    http-host := host
+    http-port := null
+    colon-pos := http-host.index-of ":"
+    if colon-pos >= 0:
+      http-port = int.parse http-host[colon-pos + 1..]
+      http-host = http-host[..colon-pos]
+    der := root-certificate-der
+    http-config := ServerConfigHttp
+        name
+        --host=http-host
+        --port=http-port
+        --path="/functions/v1/b"  // TODO(florian): get the path from the config.
+        --poll-interval=poll-interval
+        --root-certificate-names=null
+        --root-certificate-ders=der ? [der] : null
+        --admin-headers=null
+        --device-headers=null
+    return http-config.to-service-json --der-serializer=der-serializer
 
   root-certificate-ders -> List?:
     return root-certificate-der and [root-certificate-der]

--- a/tests/broker.toit
+++ b/tests/broker.toit
@@ -40,7 +40,11 @@ class TestBroker:
 
   with-service [block]:
     logger := log.default.with-name "testing-service"
-    broker-service := BrokerService logger server-config
+    service-config := ServerConfig.from-json
+        server-config.name
+        server-config.to-service-json --der-serializer=: unreachable
+        --der-deserializer=: unreachable
+    broker-service := BrokerService logger service-config
     block.call broker-service
 
 interface BrokerBackdoor:

--- a/tests/utils.toit
+++ b/tests/utils.toit
@@ -755,7 +755,7 @@ class TestDevicePipe extends TestDevice:
       --toit-run/string
       --test-cli/TestCli:
 
-    broker-config-json := broker.server-config.to-json --der-serializer=: unreachable
+    broker-config-json := broker.server-config.to-service-json --der-serializer=: unreachable
     encoded-broker-config := json.stringify broker-config-json
 
     command_ = [


### PR DESCRIPTION
No need to send a Supabase config to a device when we then always convert it to an HTTP one anyway.