### PR TITLE
Don't warn about missing bases when migrating.

### DIFF
--- a/src/cli/fleet.toit
+++ b/src/cli/fleet.toit
@@ -718,7 +718,12 @@ class FleetWithDevices extends Fleet:
       group-name := fleet-device.group
       pods-per-group.get group-name --init=: download (pod-reference-for-group group-name)
 
-    broker.roll-out --devices=detailed-devices.values --pods=pods --diff-bases=diff-bases
+    is-migrating := not fleet-file_.migrating-from.is-empty
+    broker.roll-out
+        --devices=detailed-devices.values
+        --pods=pods
+        --diff-bases=diff-bases
+        --warn-only-trivial=not is-migrating
 
     ui_.info "Successfully updated $(fleet-devices.size) device$(fleet-devices.size == 1 ? "" : "s")."
 

--- a/tests/cmd-fleet-migration-test-slow.toit
+++ b/tests/cmd-fleet-migration-test-slow.toit
@@ -46,7 +46,12 @@ main args:
 
     initial2.stop
 
-    fleet.run ["fleet", "roll-out"]
+    output := fleet.run ["fleet", "roll-out"]
+
+    // Expect only one warning for the never-started device.
+    expect (output.contains " (never-started) is unknown. Upgrade might not use patches.")
+    patches-index := output.index-of "Upgrade might not use patches."
+    expect-equals -1 (output.index-of "Upgrade might not use patches." patches-index + 1)
 
     status := initial1.wait-to-be-on-broker new1
     expect-not-equals new1.name (initial2.get-current-broker --status=status)


### PR DESCRIPTION
We might still get the warnings when there is more than one old server, but that should be so rarer that it's not worth making the code more complicated for that.