### PR TITLE
Use the service-json when exporting recovery server info.

### DIFF
--- a/src/cli/fleet.toit
+++ b/src/cli/fleet.toit
@@ -474,7 +474,7 @@ class Fleet:
 
   recovery-info -> ByteArray:
     broker.server-config.fill-certificate-ders: certificate-roots.MAP[it].raw
-    json-config := broker.server-config.to-json
+    json-config := broker.server-config.to-service-json
         --base64
         --der-serializer=: unreachable
     return json.encode json-config


### PR DESCRIPTION
The client doesn't understand supabase anymore. We need to send it the service json which automatically converts supabase into http configs.