### PR TITLE
Update the supabase configs.

### DIFF
--- a/public/supabase_broker/supabase/config.toml
+++ b/public/supabase_broker/supabase/config.toml
@@ -33,6 +33,10 @@ port = 56324
 smtp_port = 56325
 pop3_port = 56326
 
+[analytics]
+# Port to use for the analytics URL.
+port = 56327
+
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.

--- a/supabase_artemis/supabase/config.toml
+++ b/supabase_artemis/supabase/config.toml
@@ -33,6 +33,10 @@ port = 55324
 smtp_port = 55325
 pop3_port = 55326
 
+[analytics]
+# Port to use for the analytics URL.
+port = 55327
+
 [storage]
 # The maximum file size allowed (e.g. "5MB", "500KB").
 file_size_limit = "50MiB"


### PR DESCRIPTION
On recent supabase-clis the ports are used even though the services aren't started. Without changing them we can't run two Supabase instances.