### PR TITLE
Remove unnecessary check.

### DIFF
--- a/tests/supabase-broker-policies-shared.toit
+++ b/tests/supabase-broker-policies-shared.toit
@@ -218,10 +218,6 @@ run-shared-test
       expect-throws --contains="Not found":
           client-anon.storage.download --public --path=path
 
-    // Anon doesn't see it with regular download.
-    expect-throws --contains="Not found":
-        client-anon.storage.download --path=path
-
     // Check that anon can't update it.
     expect-throws --contains="row-level security":
       client-anon.storage.upload


### PR DESCRIPTION
We were testing that anon can download a file if it uses the public URL,
   but not if it uses the regular download.

It looks like newer versions of Supabase now also allow to download it regularly, and tests broke. Since the data was already publicly accessible there isn't a security issue and we can just drop the check.