### PR TITLE
Rename ArtemisServerCli to AuthProvider; delete debug-only notify-created.

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -21,7 +21,7 @@ import .pod-specification
 
 import .utils
 
-import .artemis-servers.artemis-server
+import .auth-providers.auth-provider
 import .brokers.broker
 import .sdk
 import .organization
@@ -31,7 +31,7 @@ import .server-config
 Manages devices that have an Artemis service running on them.
 */
 class Artemis:
-  artemis-server_/ArtemisServerCli? := null
+  auth-provider_/AuthProvider? := null
   network_/net.Interface? := null
 
   cli_/Cli
@@ -47,9 +47,9 @@ class Artemis:
   If the manager opened any connections, closes them as well.
   */
   close:
-    if artemis-server_: artemis-server_.close
+    if auth-provider_: auth-provider_.close
     if network_: network_.close
-    artemis-server_ = null
+    auth-provider_ = null
     network_ = null
 
   /** Opens the network. */
@@ -58,31 +58,31 @@ class Artemis:
     network_ = net.open
 
   /**
-  Returns a connected artemis-server, using the $server-config to connect.
+  Returns a connected auth provider, using the $server-config to connect.
 
-  If $authenticated is true (the default), calls $ArtemisServerCli.ensure-authenticated.
+  If $authenticated is true (the default), calls $AuthProvider.ensure-authenticated.
   */
-  connected-artemis-server_ --authenticated/bool=true -> ArtemisServerCli:
-    if not artemis-server_:
+  connected-auth-provider_ --authenticated/bool=true -> AuthProvider:
+    if not auth-provider_:
       connect-network_
-      artemis-server_ = ArtemisServerCli network_ server-config --cli=cli_
+      auth-provider_ = AuthProvider network_ server-config --cli=cli_
     if authenticated:
-      artemis-server_.ensure-authenticated: | error-message |
+      auth-provider_.ensure-authenticated: | error-message |
         cli_.ui.abort "$error-message (artemis)."
-    return artemis-server_
+    return auth-provider_
 
   /**
   Ensures that the user is authenticated with the Artemis server.
   */
   ensure-authenticated -> none:
-    connected-artemis-server_
+    connected-auth-provider_
 
   notify-created --hardware-id/Uuid:
-    server := connected-artemis-server_
+    server := connected-auth-provider_
     server.notify-created --hardware-id=hardware-id
 
   create-device --device-id/Uuid? --organization-id/Uuid -> Device:
-    return connected-artemis-server_.create-device-in-organization
+    return connected-auth-provider_.create-device-in-organization
         --device-id=device-id
         --organization-id=organization-id
 
@@ -92,7 +92,7 @@ class Artemis:
   Returns null if the organization doesn't exist.
   */
   get-organization --id/Uuid -> OrganizationDetailed?:
-    return connected-artemis-server_.get-organization id
+    return connected-auth-provider_.get-organization id
 
 service-path-in-repository root/string --chip-family/string -> string:
   return "$root/src/service/run/$(chip-family).toit"

--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -77,10 +77,6 @@ class Artemis:
   ensure-authenticated -> none:
     connected-auth-provider_
 
-  notify-created --hardware-id/Uuid:
-    server := connected-auth-provider_
-    server.notify-created --hardware-id=hardware-id
-
   create-device --device-id/Uuid? --organization-id/Uuid -> Device:
     return connected-auth-provider_.create-device-in-organization
         --device-id=device-id

--- a/src/cli/auth_providers/auth-provider.toit
+++ b/src/cli/auth_providers/auth-provider.toit
@@ -68,14 +68,6 @@ interface AuthProvider implements Authenticatable:
   */
   create-device-in-organization --organization-id/Uuid --device-id/Uuid? -> Device
 
-  /**
-  Notifies the server that the device with the given $hardware-id was created.
-
-  This operation is mostly for debugging purposes, as the $create-device-in-organization
-    already has a similar effect.
-  */
-  notify-created --hardware-id/Uuid
-
   /** Returns the used-id of the authenticated user. */
   get-current-user-id -> string
 

--- a/src/cli/auth_providers/auth-provider.toit
+++ b/src/cli/auth_providers/auth-provider.toit
@@ -5,8 +5,8 @@ import log
 import net
 import uuid show Uuid
 
-import .supabase show ArtemisServerCliSupabase
-import .http.base show ArtemisServerCliHttpToit
+import .supabase show AuthProviderSupabase
+import .http.base show AuthProviderHttpToit
 import ...shared.server-config
 import ..auth
 import ..config
@@ -16,12 +16,12 @@ import ..organization
 /**
 An abstraction for the Artemis server.
 */
-interface ArtemisServerCli implements Authenticatable:
+interface AuthProvider implements Authenticatable:
   constructor network/net.Interface server-config/ServerConfig --cli/Cli:
     if server-config is ServerConfigSupabase:
-      return ArtemisServerCliSupabase network (server-config as ServerConfigSupabase) --cli=cli
+      return AuthProviderSupabase network (server-config as ServerConfigSupabase) --cli=cli
     if server-config is ServerConfigHttp:
-      return ArtemisServerCliHttpToit network (server-config as ServerConfigHttp) --cli=cli
+      return AuthProviderHttpToit network (server-config as ServerConfigHttp) --cli=cli
     throw "UNSUPPORTED ARTEMIS SERVER CONFIG"
 
   is-closed -> bool
@@ -140,11 +140,11 @@ interface ArtemisServerCli implements Authenticatable:
   // TODO(florian): add support for changing the email.
   update-profile --name/string
 
-with-server server-config/ServerConfig --cli/Cli [block]:
+with-auth-provider server-config/ServerConfig --cli/Cli [block]:
   network := net.open
-  server/ArtemisServerCli? := null
+  server/AuthProvider? := null
   try:
-    server = ArtemisServerCli network server-config --cli=cli
+    server = AuthProvider network server-config --cli=cli
     block.call server
   finally:
     if server: server.close

--- a/src/cli/auth_providers/http/base.toit
+++ b/src/cli/auth_providers/http/base.toit
@@ -10,7 +10,7 @@ import encoding.json
 import encoding.base64
 import uuid show Uuid
 
-import ..artemis-server
+import ..auth-provider
 import ...config
 import ...device
 import ...organization
@@ -19,7 +19,7 @@ import ....shared.server-config
 import ....shared.utils as utils
 import ....shared.constants show *
 
-class ArtemisServerCliHttpToit implements ArtemisServerCli:
+class AuthProviderHttpToit implements AuthProvider:
   client_/http.Client? := ?
   server-config_/ServerConfigHttp
   current-user-id_/Uuid? := null

--- a/src/cli/auth_providers/http/base.toit
+++ b/src/cli/auth_providers/http/base.toit
@@ -87,12 +87,6 @@ class AuthProviderHttpToit implements AuthProvider:
         --id=Uuid.parse device-info["alias"]
         --organization-id=Uuid.parse device-info["organization_id"]
 
-  notify-created --hardware-id/Uuid -> none:
-    send-request_ COMMAND-NOTIFY-ARTEMIS-CREATED_ {
-      "hardware_id": "$hardware-id",
-      "data": { "type": "created" },
-    }
-
   get-current-user-id -> Uuid:
     return current-user-id_
 

--- a/src/cli/auth_providers/supabase/supabase.toit
+++ b/src/cli/auth_providers/supabase/supabase.toit
@@ -73,12 +73,6 @@ class AuthProviderSupabase implements AuthProvider:
         --id=Uuid.parse inserted["alias"]
         --organization-id=Uuid.parse inserted["organization_id"]
 
-  notify-created --hardware-id/Uuid -> none:
-    client_.rest.insert "events" --no-return-inserted {
-      "device_id": "$hardware-id",
-      "data": { "type": "created" }
-    }
-
   get-current-user-id -> Uuid:
     return Uuid.parse client_.auth.get-current-user["id"]
 

--- a/src/cli/auth_providers/supabase/supabase.toit
+++ b/src/cli/auth_providers/supabase/supabase.toit
@@ -9,7 +9,7 @@ import supabase
 import supabase.filter show equals is-null orr
 import uuid show Uuid
 
-import ..artemis-server
+import ..auth-provider
 import ...config
 import ...device
 import ...organization
@@ -19,7 +19,7 @@ import ....shared.server-config
 
 TOIT_IO_AUTH_REDIRECT_URL ::= "https://toit.io/auth"
 
-class ArtemisServerCliSupabase implements ArtemisServerCli:
+class AuthProviderSupabase implements AuthProvider:
   client_/supabase.Client? := ?
   server-config_/ServerConfigSupabase
 

--- a/src/cli/cmds/auth.toit
+++ b/src/cli/cmds/auth.toit
@@ -8,7 +8,7 @@ import ..cache
 import ..config
 import ..auth show Authenticatable
 import ..server-config
-import ..artemis-servers.artemis-server show with-server ArtemisServerCli
+import ..auth-providers.auth-provider show with-auth-provider AuthProvider
 import ..brokers.broker show with-broker BrokerCli
 
 SIGNIN-OPTIONS ::= [
@@ -181,7 +181,7 @@ with-authenticatable invocation/Invocation [block]:
       block.call server-config.name broker
   else:
     server-config = get-server-from-config --cli=cli --key=CONFIG-ARTEMIS-DEFAULT-KEY
-    with-server server-config --cli=cli: | server/ArtemisServerCli |
+    with-auth-provider server-config --cli=cli: | server/AuthProvider |
       block.call server-config.name server
 
 sign-in invocation/Invocation:

--- a/src/cli/cmds/org.toit
+++ b/src/cli/cmds/org.toit
@@ -9,7 +9,7 @@ import ..config
 import ..cache
 import ..server-config
 import ..organization
-import ..artemis-servers.artemis-server show with-server ArtemisServerCli
+import ..auth-providers.auth-provider show with-auth-provider AuthProvider
 import ..utils
 
 create-org-commands -> List:
@@ -226,7 +226,7 @@ with-org-server invocation/Invocation [block]:
   server-config/ServerConfig := ?
   server-config = get-server-from-config --key=CONFIG-ARTEMIS-DEFAULT-KEY --cli=cli
 
-  with-server server-config --cli=cli: | server/ArtemisServerCli |
+  with-auth-provider server-config --cli=cli: | server/AuthProvider |
     server.ensure-authenticated: | error-message |
       ui.abort "$error-message (artemis)."
     block.call server
@@ -246,7 +246,7 @@ with-org-server-id invocation/Invocation [block]:
     block.call server org-id
 
 list-orgs invocation/Invocation -> none:
-  with-org-server invocation: | server/ArtemisServerCli |
+  with-org-server invocation: | server/AuthProvider |
     orgs := server.get-organizations
     invocation.cli.ui.emit-table --result
           --header={"id": "ID", "name": "Name"}
@@ -257,16 +257,16 @@ list-orgs invocation/Invocation -> none:
 
 add-org invocation/Invocation -> none:
   should-make-default := invocation["default"]
-  with-org-server invocation: | server/ArtemisServerCli |
+  with-org-server invocation: | server/AuthProvider |
     org := server.create-organization invocation["name"]
     invocation.cli.ui.emit --info "Added organization $org.id - $org.name."
     if should-make-default: make-default_ org --cli=invocation.cli
 
 show-org invocation/Invocation -> none:
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid |
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid |
     print-org org-id server --cli=invocation.cli
 
-print-org org-id/Uuid server/ArtemisServerCli --cli/Cli -> none:
+print-org org-id/Uuid server/AuthProvider --cli/Cli -> none:
   ui := cli.ui
   org := server.get-organization org-id
   if not org:
@@ -309,12 +309,12 @@ default-org invocation/Invocation -> none:
       ui.emit --result "$org-id"
       return
 
-    with-org-server invocation: | server/ArtemisServerCli |
+    with-org-server invocation: | server/AuthProvider |
       print-org org-id server --cli=cli
 
     return
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid |
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid |
     org/OrganizationDetailed? := null
     exception := catch: org = server.get-organization org-id
     if exception or not org:
@@ -337,14 +337,14 @@ update-org invocation/Invocation -> none:
   if not name: ui.abort "No name provided."
   if name == "": ui.abort "Name cannot be empty."
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid |
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid |
     server.update-organization org-id --name=name
     ui.emit --info "Updated organization $org-id."
 
 member-list invocation/Invocation -> none:
   ui := invocation.cli.ui
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid |
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid |
     members := server.get-organization-members org-id
     if invocation["id-only"]:
       member-ids := members.map: "$it["id"]"
@@ -375,7 +375,7 @@ member-add invocation/Invocation -> none:
   user-id := invocation["user-id"]
   role := invocation["role"]
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid|
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid|
     existing-members := server.get-organization-members org-id
     if (existing-members.any: it["id"] == user-id):
       ui.abort "User $user-id is already a member of organization $org-id."
@@ -391,7 +391,7 @@ member-remove invocation/Invocation -> none:
   user-id := invocation["user-id"]
   force := invocation["force"]
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid |
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid |
     if not force:
       current-user-id := server.get-current-user-id
       if user-id == current-user-id:
@@ -405,7 +405,7 @@ member-set-role invocation/Invocation -> none:
   user-id := invocation["user-id"]
   role := invocation["role"]
 
-  with-org-server-id invocation: | server/ArtemisServerCli org-id/Uuid|
+  with-org-server-id invocation: | server/AuthProvider org-id/Uuid|
     server.organization-member-set-role
         --organization-id=org-id
         --user-id=user-id

--- a/src/cli/cmds/profile.toit
+++ b/src/cli/cmds/profile.toit
@@ -6,7 +6,7 @@ import net
 import ..config
 import ..cache
 import ..server-config
-import ..artemis-servers.artemis-server show with-server ArtemisServerCli
+import ..auth-providers.auth-provider show with-auth-provider AuthProvider
 
 create-profile-commands -> List:
   profile-cmd := Command "profile"
@@ -40,14 +40,14 @@ with-profile-server invocation/Invocation [block]:
 
   server-config := get-server-from-config --key=CONFIG-ARTEMIS-DEFAULT-KEY --cli=cli
 
-  with-server server-config --cli=cli: | server/ArtemisServerCli |
+  with-auth-provider server-config --cli=cli: | server/AuthProvider |
     server.ensure-authenticated: | error-message |
       cli.ui.abort "$error-message (artemis)."
     block.call server
 
 show-profile invocation/Invocation:
   ui := invocation.cli.ui
-  with-profile-server invocation: | server/ArtemisServerCli |
+  with-profile-server invocation: | server/AuthProvider |
     profile := server.get-profile
     if ui.wants-structured --kind=Ui.RESULT:
       // We recreate the map, so we don't show unnecessary entries.
@@ -73,6 +73,6 @@ update-profile invocation/Invocation:
   if not name:
     ui.abort "No name specified."
 
-  with-profile-server invocation: | server/ArtemisServerCli |
+  with-profile-server invocation: | server/AuthProvider |
     server.update-profile --name=name
     ui.emit --info "Profile updated."

--- a/src/cli/cmds/sdk.toit
+++ b/src/cli/cmds/sdk.toit
@@ -8,7 +8,7 @@ import ..config
 import ..cache
 import ..fleet
 import ..server-config
-import ..artemis-servers.artemis-server show with-server ArtemisServerCli
+import ..auth-providers.auth-provider show with-auth-provider AuthProvider
 import .utils_
 
 create-sdk-commands -> List:

--- a/src/cli/fleet.toit
+++ b/src/cli/fleet.toit
@@ -1041,10 +1041,7 @@ class FleetWithDevices extends Fleet:
         --device-id=device-id
         --organization-id=organization-id
     assert: device.id == device-id
-    hardware-id := device.hardware-id
 
-    // Insert an initial event mostly for testing purposes.
-    artemis.notify-created --hardware-id=hardware-id
     broker.notify-created device
 
     write-identity-file device --out-path=out-path

--- a/src/shared/constants.toit
+++ b/src/shared/constants.toit
@@ -7,7 +7,6 @@ COMMAND-SIGN-UP_ ::= 2
 COMMAND-SIGN-IN_ ::= 3
 COMMAND-GET-ORGANIZATIONS_ ::= 4
 COMMAND-UPDATE-CURRENT-USER_ ::= 18
-COMMAND-NOTIFY-ARTEMIS-CREATED_ ::= 5
 COMMAND-GET-ORGANIZATION-DETAILS_ ::= 6
 COMMAND-CREATE-ORGANIZATION_ ::= 7
 COMMAND-UPDATE-ORGANIZATION_ ::= 8
@@ -25,7 +24,6 @@ ARTEMIS-COMMAND-TO-STRING ::= {
   COMMAND-SIGN-IN_: "sign-in",
   COMMAND-GET-ORGANIZATIONS_: "get-organizations",
   COMMAND-UPDATE-CURRENT-USER_: "update-current-user",
-  COMMAND-NOTIFY-ARTEMIS-CREATED_: "notify-artemis-created",
   COMMAND-GET-ORGANIZATION-DETAILS_: "get-organization-details",
   COMMAND-CREATE-ORGANIZATION_: "create-organization",
   COMMAND-UPDATE-ORGANIZATION_: "update-organization",
@@ -46,12 +44,7 @@ COMMAND-DOWNLOAD-PRIVATE_ ::= 3
 // As of 2024-03-22 unused. Newer CLIs use $COMMAND-UPDATE-GOALS_ instead.
 COMMAND-UPDATE-GOAL_ ::= 4
 COMMAND-GET-DEVICES_ ::= 5
-/**
-Command to notify the Artemis server that a broker has been created.
-
-To avoid accidental confusion with $COMMAND-NOTIFY-ARTEMIS-CREATED_, the
-  command has the same constants.
-*/
+/** Command to notify the broker that a device has been created. */
 COMMAND-NOTIFY-BROKER-CREATED_ ::= 6
 COMMAND-GET-EVENTS_ ::= 7
 COMMAND-UPDATE-GOALS_ ::= 8

--- a/tests/auth-provider-test.toit
+++ b/tests/auth-provider-test.toit
@@ -39,13 +39,12 @@ run-test artemis-server/TestArtemisServer [--authenticate]:
     network := net.open
     server-cli := AuthProvider network server-config --cli=cli
     authenticate.call server-cli
-    hardware-id := test-create-device-in-organization server-cli backdoor
-    test-notify-created server-cli backdoor --hardware-id=hardware-id
+    test-create-device-in-organization server-cli backdoor
 
     test-organizations server-cli backdoor
     test-profile server-cli backdoor
 
-test-create-device-in-organization server-cli/AuthProvider backdoor/ArtemisServerBackdoor -> Uuid:
+test-create-device-in-organization server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
   // Test without and with alias.
   device1 := server-cli.create-device-in-organization
       --device-id=null
@@ -65,13 +64,6 @@ test-create-device-in-organization server-cli/AuthProvider backdoor/ArtemisServe
   expect-equals hardware-id2 data[0]
   expect-equals TEST-ORGANIZATION-UUID data[1]
   expect-equals alias-id data[2]
-
-  return hardware-id2
-
-test-notify-created server-cli/AuthProvider backdoor/ArtemisServerBackdoor --hardware-id/Uuid:
-  expect-not (backdoor.has-event --hardware-id=hardware-id --type="created")
-  server-cli.notify-created --hardware-id=hardware-id
-  expect (backdoor.has-event --hardware-id=hardware-id --type="created")
 
 test-organizations server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
   original-orgs := server-cli.get-organizations

--- a/tests/auth-provider-test.toit
+++ b/tests/auth-provider-test.toit
@@ -12,7 +12,7 @@ import uuid show Uuid
 import .artemis-server
 import .utils
 
-import artemis.cli.artemis-servers.artemis-server show ArtemisServerCli
+import artemis.cli.auth-providers.auth-provider show AuthProvider
 import artemis.shared.server-config show ServerConfig
 import artemis.cli.auth as cli-auth
 
@@ -27,7 +27,7 @@ main args:
   else:
     throw "Unknown server server type: $args[0]"
   with-artemis-server --args=args --type=server-type: | artemis-server/TestArtemisServer |
-    run-test artemis-server --authenticate=: | server/ArtemisServerCli |
+    run-test artemis-server --authenticate=: | server/AuthProvider |
       server.sign-in
             --email=TEST-EXAMPLE-COM-EMAIL
             --password=TEST-EXAMPLE-COM-PASSWORD
@@ -37,7 +37,7 @@ run-test artemis-server/TestArtemisServer [--authenticate]:
   backdoor := artemis-server.backdoor
   with-tmp-config-cli: | cli/Cli |
     network := net.open
-    server-cli := ArtemisServerCli network server-config --cli=cli
+    server-cli := AuthProvider network server-config --cli=cli
     authenticate.call server-cli
     hardware-id := test-create-device-in-organization server-cli backdoor
     test-notify-created server-cli backdoor --hardware-id=hardware-id
@@ -45,7 +45,7 @@ run-test artemis-server/TestArtemisServer [--authenticate]:
     test-organizations server-cli backdoor
     test-profile server-cli backdoor
 
-test-create-device-in-organization server-cli/ArtemisServerCli backdoor/ArtemisServerBackdoor -> Uuid:
+test-create-device-in-organization server-cli/AuthProvider backdoor/ArtemisServerBackdoor -> Uuid:
   // Test without and with alias.
   device1 := server-cli.create-device-in-organization
       --device-id=null
@@ -68,12 +68,12 @@ test-create-device-in-organization server-cli/ArtemisServerCli backdoor/ArtemisS
 
   return hardware-id2
 
-test-notify-created server-cli/ArtemisServerCli backdoor/ArtemisServerBackdoor --hardware-id/Uuid:
+test-notify-created server-cli/AuthProvider backdoor/ArtemisServerBackdoor --hardware-id/Uuid:
   expect-not (backdoor.has-event --hardware-id=hardware-id --type="created")
   server-cli.notify-created --hardware-id=hardware-id
   expect (backdoor.has-event --hardware-id=hardware-id --type="created")
 
-test-organizations server-cli/ArtemisServerCli backdoor/ArtemisServerBackdoor:
+test-organizations server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
   original-orgs := server-cli.get-organizations
 
   // For now we can't be sure that there aren't other organizations from
@@ -164,7 +164,7 @@ test-organizations server-cli/ArtemisServerCli backdoor/ArtemisServerBackdoor:
   // Keep the demo user in the same organization as the test user,
   // so we can read the user's profile in 'test_profile'
 
-test-profile server-cli/ArtemisServerCli backdoor/ArtemisServerBackdoor:
+test-profile server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
   profile := server-cli.get-profile
 
   profile = server-cli.get-profile

--- a/tools/http_servers/artemis-server.toit
+++ b/tools/http_servers/artemis-server.toit
@@ -103,8 +103,6 @@ class HttpArtemisServer extends HttpServer:
       return store-event data
     if command == COMMAND-CREATE-DEVICE-IN-ORGANIZATION_:
       return create-device-in-organization data
-    if command == COMMAND-NOTIFY-ARTEMIS-CREATED_:
-      return store-event data
     if command == COMMAND-SIGN-UP_:
       return sign-up data
     if command == COMMAND-SIGN-IN_:


### PR DESCRIPTION
The CLI-side interface previously called `ArtemisServerCli` is really
an identity / auth provider abstraction. Renaming it to `AuthProvider`
matches its responsibility and prepares for the upcoming phase where
each service (broker, pod-store, fleet-store) optionally references its
own named auth provider.

## Rename
- `src/cli/artemis_servers/` → `src/cli/auth_providers/`
- `artemis-server.toit` → `auth-provider.toit`
- `ArtemisServerCli` → `AuthProvider` (+ the two impls, the helper,
  internal field/method on `Artemis`)
- `tests/artemis-server-test.toit` → `tests/auth-provider-test.toit`

The HTTP test server (`tools/http_servers/artemis-server.toit`) and the
test helper (`tests/artemis-server.toit`) keep their names — they
simulate or talk to the production Artemis server, which keeps that
external name.

## Delete `AuthProvider.notify-created`
The method was documented as "mostly for debugging purposes" and just
appended a `{"type": "created"}` event row. Nothing depends on it; the
broker has its own (load-bearing) `notify-created`. Removes the
interface declaration, both impls, the lone caller in `fleet.toit`, the
HTTP test server dispatch branch, and the
`COMMAND-NOTIFY-ARTEMIS-CREATED_` constant + string mapping.

## Compatibility
No Supabase schema or RLS changes. Old CLIs in the field that call
`notify-created` against the Supabase server continue to hit the
existing function (it remains defined in the schema); we just stop
calling it from the new CLI.