### PR TITLE
Move device creation from AuthProvider to broker.

### DIFF
--- a/src/cli/artemis.toit
+++ b/src/cli/artemis.toit
@@ -77,11 +77,6 @@ class Artemis:
   ensure-authenticated -> none:
     connected-auth-provider_
 
-  create-device --device-id/Uuid? --organization-id/Uuid -> Device:
-    return connected-auth-provider_.create-device-in-organization
-        --device-id=device-id
-        --organization-id=organization-id
-
   /**
   Fetches the organizations with the given $id.
 

--- a/src/cli/auth_providers/auth-provider.toit
+++ b/src/cli/auth_providers/auth-provider.toit
@@ -60,14 +60,6 @@ interface AuthProvider implements Authenticatable:
   */
   logout
 
-  /**
-  Adds a new device to the organization with the given $organization-id.
-
-  Takes a $device-id, representing the user's chosen name for the device.
-  The $device-id may be null in which case the server creates an alias.
-  */
-  create-device-in-organization --organization-id/Uuid --device-id/Uuid? -> Device
-
   /** Returns the used-id of the authenticated user. */
   get-current-user-id -> string
 

--- a/src/cli/auth_providers/http/base.toit
+++ b/src/cli/auth_providers/http/base.toit
@@ -75,18 +75,6 @@ class AuthProviderHttpToit implements AuthProvider:
     cli_.config.remove "$(CONFIG-SERVER-AUTHS-KEY).$(server-config_.name)"
     cli_.config.write
 
-  create-device-in-organization --organization-id/Uuid --device-id/Uuid? -> Device:
-    map := {
-      "organization_id": "$organization-id",
-    }
-    if device-id: map["alias"] = "$device-id"
-
-    device-info := send-request_ COMMAND-CREATE-DEVICE-IN-ORGANIZATION_ map
-    return Device
-        --hardware-id=Uuid.parse device-info["id"]
-        --id=Uuid.parse device-info["alias"]
-        --organization-id=Uuid.parse device-info["organization_id"]
-
   get-current-user-id -> Uuid:
     return current-user-id_
 

--- a/src/cli/auth_providers/supabase/supabase.toit
+++ b/src/cli/auth_providers/supabase/supabase.toit
@@ -60,19 +60,6 @@ class AuthProviderSupabase implements AuthProvider:
   logout:
     client_.auth.logout
 
-  create-device-in-organization --organization-id/Uuid --device-id/Uuid? -> Device:
-    payload := {
-      "organization_id": "$organization-id",
-    }
-
-    if device-id: payload["alias"] = "$device-id"
-
-    inserted := client_.rest.insert "devices" payload
-    return Device
-        --hardware-id=Uuid.parse inserted["id"]
-        --id=Uuid.parse inserted["alias"]
-        --organization-id=Uuid.parse inserted["organization_id"]
-
   get-current-user-id -> Uuid:
     return Uuid.parse client_.auth.get-current-user["id"]
 

--- a/src/cli/broker.toit
+++ b/src/cli/broker.toit
@@ -703,7 +703,10 @@ class Broker:
     state := {
       "identity": identity,
     }
-    broker-connection_.notify-created --device-id=device.id --state=state
+    broker-connection_.notify-created
+        --hardware-id=device.hardware-id
+        --device-id=device.id
+        --state=state
 
   device-for --id/Uuid -> DeviceDetailed:
     devices := broker-connection_.get-devices --device-ids=[id]

--- a/src/cli/brokers/broker.toit
+++ b/src/cli/brokers/broker.toit
@@ -124,11 +124,15 @@ interface BrokerCli implements Authenticatable:
   download-firmware --id/string -> ByteArray
 
   /**
-  Informs the broker that a device with the given $device-id has been provisioned.
-  The $state map is the initial state of the device. Until it connects to the
-    broker there is (probably) only identity information in it.
+  Informs the broker that a new device has been provisioned.
+
+  The broker registers the device under the configured scope (from its
+    server-config). For a shared-tenancy broker, this also creates the
+    corresponding record on the auth side. The $state map is the initial
+    state of the device; until it connects to the broker there is
+    (probably) only identity information in it.
   */
-  notify-created --device-id/Uuid --state/Map -> none
+  notify-created --hardware-id/Uuid --device-id/Uuid --state/Map -> none
 
   /**
   Fetches all events of the given $types for all devices in the $device-ids list.

--- a/src/cli/brokers/http/base.toit
+++ b/src/cli/brokers/http/base.toit
@@ -208,7 +208,10 @@ class BrokerCliHttp implements BrokerCli:
       "path": "/toit-artemis-assets/$scope/firmware/$id",
     }
 
-  notify-created --device-id/Uuid --state/Map -> none:
+  notify-created --hardware-id/Uuid --device-id/Uuid --state/Map -> none:
+    // hardware-id is only used by overrides (e.g., the Supabase variant
+    // writing into the auth-side devices table). The on-the-wire
+    // notify-broker-created RPC takes just the device-id and state.
     send-request_ COMMAND-NOTIFY-BROKER-CREATED_ {
       "_device_id": "$device-id",
       "_state": state,

--- a/src/cli/brokers/supabase/supabase.toit
+++ b/src/cli/brokers/supabase/supabase.toit
@@ -4,6 +4,7 @@ import cli show Cli
 import http
 import supabase
 import certificate-roots
+import uuid show Uuid
 
 import ..http.base
 import ...config
@@ -35,6 +36,7 @@ create-broker-cli-supabase-http server-config/ServerConfigSupabase --cli/Cli -> 
       --root-certificate-ders=server-config.root-certificate-der ? [server-config.root-certificate-der] : null
       --poll-interval=server-config.poll-interval
       --scope=server-config.scope
+      --tenancy=server-config.tenancy
 
   return BrokerCliSupabase --id=id supabase-client http-config
 
@@ -68,6 +70,23 @@ class BrokerCliSupabase extends BrokerCliHttp:
 
   logout:
     supabase-client_.auth.logout
+
+  /**
+  Registers a newly provisioned device with the broker.
+
+  For a shared-tenancy deployment the broker and the auth provider live
+    in the same Supabase project; the broker is responsible for creating
+    the device row in the auth-side `devices` table as part of the
+    notify-created handshake.
+  */
+  notify-created --hardware-id/Uuid --device-id/Uuid --state/Map -> none:
+    if server-config_.tenancy == TENANCY-SHARED:
+      supabase-client_.rest.insert "devices" --no-return-inserted {
+        "id": "$hardware-id",
+        "alias": "$device-id",
+        "organization_id": server-config_.scope.to-json,
+      }
+    super --hardware-id=hardware-id --device-id=device-id --state=state
 
   extra-headers -> Map:
     bearer/string := supabase-client_.session_

--- a/src/cli/fleet.toit
+++ b/src/cli/fleet.toit
@@ -1094,22 +1094,23 @@ class FleetWithDevices extends Fleet:
   /**
   Provisions a device.
 
-  Contacts the Artemis server and creates a new device entry with the
-    given $device-id (used as "alias" on the server side) in the
-    organization with the given $organization-id.
+  Mints a fresh hardware-id locally and registers the device with the
+    broker (which, for a shared-tenancy deployment, also creates the
+    corresponding row in the auth provider's device table).
 
   Writes the identity file to $out-path.
   */
-  provision --device-id/Uuid? --out-path/string:
-    // Ensure that we are authenticated with both the Artemis server and the broker.
-    // We don't want to create a device on Artemis and then have an error with the broker.
+  provision --device-id/Uuid --out-path/string:
+    // Ensure that we are authenticated with both the auth provider and
+    // the broker before doing anything visible. The auth-provider check
+    // gates access; the broker is what actually receives the new device.
     artemis.ensure-authenticated
     broker.ensure-authenticated
 
-    device := artemis.create-device
-        --device-id=device-id
+    device := Device
+        --hardware-id=random-uuid
+        --id=device-id
         --organization-id=organization-id
-    assert: device.id == device-id
 
     broker.notify-created device
 

--- a/src/shared/constants.toit
+++ b/src/shared/constants.toit
@@ -2,7 +2,6 @@
 
 /* Artemis commands. */
 COMMAND-CHECK-IN_ ::= 0
-COMMAND-CREATE-DEVICE-IN-ORGANIZATION_ ::= 1
 COMMAND-SIGN-UP_ ::= 2
 COMMAND-SIGN-IN_ ::= 3
 COMMAND-GET-ORGANIZATIONS_ ::= 4
@@ -19,7 +18,6 @@ COMMAND-UPDATE-PROFILE_ ::= 14
 
 ARTEMIS-COMMAND-TO-STRING ::= {
   COMMAND-CHECK-IN_: "check-in",
-  COMMAND-CREATE-DEVICE-IN-ORGANIZATION_: "create-device-in-organization",
   COMMAND-SIGN-UP_: "sign-up",
   COMMAND-SIGN-IN_: "sign-in",
   COMMAND-GET-ORGANIZATIONS_: "get-organizations",

--- a/src/shared/server-config.toit
+++ b/src/shared/server-config.toit
@@ -8,6 +8,19 @@ import uuid show Uuid
 
 import .scope show Scope
 
+/**
+A multi-tenant deployment: the broker shares its underlying storage with
+  an auth provider (so creating a device on the broker also has to land
+  a row in the auth provider's device table).
+*/
+TENANCY-SHARED ::= "shared"
+
+/**
+A single-tenant deployment: the broker is self-contained and does not
+  need to coordinate with an auth provider's storage.
+*/
+TENANCY-DEDICATED ::= "dedicated"
+
 abstract class ServerConfig:
   name/string
 
@@ -19,10 +32,18 @@ abstract class ServerConfig:
   */
   scope/Scope?
 
+  /**
+  The deployment shape of this server.
+
+  Either $TENANCY-SHARED, $TENANCY-DEDICATED, or null (caller hasn't
+    specified; treated as dedicated by consumers).
+  */
+  tenancy/string?
+
   cache-key_/string? := null
   ders-already-installed_/bool := false
 
-  constructor.from-sub_ .name --.scope/Scope?=null:
+  constructor.from-sub_ .name --.scope/Scope?=null --.tenancy/string?=null:
 
   /**
   Creates a new broker-config from a JSON map.
@@ -142,6 +163,7 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
     if use-tls == null: use-tls = json.contains "root_certificate_name"
     scope-value := json.get "scope"
     scope/Scope? := scope-value and (Scope scope-value)
+    tenancy/string? := json.get "tenancy"
 
     return ServerConfigSupabase name
         --host=json["host"]
@@ -150,6 +172,7 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
         --use-tls=use-tls
         --root-certificate-der=root-der
         --scope=scope
+        --tenancy=tenancy
 
   constructor name/string
       --.host
@@ -157,8 +180,9 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
       --.use-tls=true
       --.root-certificate-der=null
       --.poll-interval=DEFAULT-POLL-INTERVAL
-      --scope/Scope?=null:
-    super.from-sub_ name --scope=scope
+      --scope/Scope?=null
+      --tenancy/string?=null:
+    super.from-sub_ name --scope=scope --tenancy=tenancy
 
   operator== other:
     if other is not ServerConfigSupabase: return false
@@ -189,6 +213,8 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
           result["root_certificate_der_id"] = serialized
     if scope:
       result["scope"] = scope.to-json
+    if tenancy:
+      result["tenancy"] = tenancy
     return result
 
   to-service-json [--der-serializer] --base64/bool=false -> Map:
@@ -228,6 +254,7 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
         --root-certificate-der=root-certificate-der
         --poll-interval=poll-interval
         --scope=scope
+        --tenancy=tenancy
 
   with --scope/Scope -> ServerConfigSupabase:
     return ServerConfigSupabase
@@ -238,6 +265,18 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
         --root-certificate-der=root-certificate-der
         --poll-interval=poll-interval
         --scope=scope
+        --tenancy=tenancy
+
+  with --tenancy/string -> ServerConfigSupabase:
+    return ServerConfigSupabase
+        name
+        --host=host
+        --anon=anon
+        --use-tls=use-tls
+        --root-certificate-der=root-certificate-der
+        --poll-interval=poll-interval
+        --scope=scope
+        --tenancy=tenancy
 
 /**
 A broker configuration for an HTTP-based broker.
@@ -266,6 +305,7 @@ class ServerConfigHttp extends ServerConfig:
     if use-tls == null: use-tls = config.contains "root_certificate_names"
     scope-value := config.get "scope"
     scope/Scope? := scope-value and (Scope scope-value)
+    tenancy/string? := config.get "tenancy"
     return ServerConfigHttp name
         --host=config["host"]
         --port=config.get "port"
@@ -276,6 +316,7 @@ class ServerConfigHttp extends ServerConfig:
         --admin-headers=config.get "admin_headers"
         --poll-interval=Duration --us=config["poll_interval"]
         --scope=scope
+        --tenancy=tenancy
 
   constructor name/string
       --.host
@@ -286,9 +327,10 @@ class ServerConfigHttp extends ServerConfig:
       --.device-headers
       --.admin-headers
       --.poll-interval=DEFAULT-POLL-INTERVAL
-      --scope/Scope?=null:
+      --scope/Scope?=null
+      --tenancy/string?=null:
 
-    super.from-sub_ name --scope=scope
+    super.from-sub_ name --scope=scope --tenancy=tenancy
 
   operator== other:
     if other is not ServerConfigHttp: return false
@@ -318,12 +360,15 @@ class ServerConfigHttp extends ServerConfig:
       result["admin_headers"] = admin-headers
     if scope:
       result["scope"] = scope.to-json
+    if tenancy:
+      result["tenancy"] = tenancy
     return result
 
   to-service-json [--der-serializer] --base64/bool=false -> Map:
     result := to-json --der-serializer=der-serializer --base64=base64
     result.remove "admin_headers"
     result.remove "scope"
+    result.remove "tenancy"
     return result
 
   compute-cache-key_ -> string:
@@ -341,3 +386,4 @@ class ServerConfigHttp extends ServerConfig:
         --admin-headers=admin-headers
         --poll-interval=poll-interval
         --scope=scope
+        --tenancy=tenancy

--- a/tests/artemis-server.toit
+++ b/tests/artemis-server.toit
@@ -32,14 +32,6 @@ interface ArtemisServerBackdoor:
   has-event --hardware-id/Uuid --type/string -> bool
 
   /**
-  Creates a new device in the given $organization-id.
-
-  Returns a map with the device ID ("id"), and alias ID ("alias") of
-    the created device.
-  */
-  create-device --organization-id/Uuid -> Map
-
-  /**
   Removes the device with the given $device-id.
   */
   remove-device device-id/Uuid -> none
@@ -81,19 +73,6 @@ class ToitHttpBackdoor implements ArtemisServerBackdoor:
           entry.data is Map and (entry.data.get "type") == type:
         return true
     return false
-
-  create-device --organization-id/Uuid -> Map:
-    // TODO(florian): the server should automatically generate an alias
-    // if none is given.
-    alias := random-uuid
-    response := server.create-device-in-organization {
-      "organization_id": "$organization-id",
-      "alias": "$alias",
-    }
-    return {
-      "id": Uuid.parse response["id"],
-      "alias": Uuid.parse response["alias"],
-    }
 
   remove-device device-id/Uuid -> none:
     server.remove-device "$device-id"
@@ -176,19 +155,6 @@ class SupabaseBackdoor implements ArtemisServerBackdoor:
           (it["data"].get "type") == type:
         return true
     return false
-
-  create-device --organization-id/Uuid -> Map:
-    alias := random-uuid
-    with-backdoor-client_: | client/supabase.Client |
-      response := client.rest.insert "devices" {
-        "organization_id": "$organization-id",
-        "alias": "$alias",
-      }
-      return {
-        "id": Uuid.parse response["id"],
-        "alias": Uuid.parse response["alias"],
-      }
-    unreachable
 
   remove-device device-id/Uuid -> none:
     with-backdoor-client_: | client/supabase.Client |

--- a/tests/auth-provider-test.toit
+++ b/tests/auth-provider-test.toit
@@ -39,31 +39,9 @@ run-test artemis-server/TestArtemisServer [--authenticate]:
     network := net.open
     server-cli := AuthProvider network server-config --cli=cli
     authenticate.call server-cli
-    test-create-device-in-organization server-cli backdoor
 
     test-organizations server-cli backdoor
     test-profile server-cli backdoor
-
-test-create-device-in-organization server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
-  // Test without and with alias.
-  device1 := server-cli.create-device-in-organization
-      --device-id=null
-      --organization-id=TEST-ORGANIZATION-UUID
-  hardware-id1 := device1.hardware-id
-  data := backdoor.fetch-device-information --hardware-id=hardware-id1
-  expect-equals hardware-id1 data[0]
-  expect-equals TEST-ORGANIZATION-UUID data[1]
-
-  alias-id := random-uuid
-  device2 := server-cli.create-device-in-organization
-      --device-id=alias-id
-      --organization-id=TEST-ORGANIZATION-UUID
-  sleep --ms=200
-  hardware-id2 := device2.hardware-id
-  data = backdoor.fetch-device-information --hardware-id=hardware-id2
-  expect-equals hardware-id2 data[0]
-  expect-equals TEST-ORGANIZATION-UUID data[1]
-  expect-equals alias-id data[2]
 
 test-organizations server-cli/AuthProvider backdoor/ArtemisServerBackdoor:
   original-orgs := server-cli.get-organizations

--- a/tests/broker-test.toit
+++ b/tests/broker-test.toit
@@ -80,7 +80,7 @@ run-test
       state := {
         "identity": identity,
       }
-      broker-cli.notify-created --device-id=device.id --state=state
+      broker-cli.notify-created --hardware-id=device.hardware-id --device-id=device.id --state=state
 
     network := net.open
     try:

--- a/tests/broker.toit
+++ b/tests/broker.toit
@@ -22,6 +22,7 @@ import artemis.shared.server-config
     ServerConfig
     ServerConfigHttp
     ServerConfigSupabase
+    TENANCY-SHARED
 import .utils
 
 class TestBroker:
@@ -54,9 +55,13 @@ class TestBroker:
 
 interface BrokerBackdoor:
   /**
-  Creates a new device with the given $device-id and initial $state.
+  Creates a new device with the given $hardware-id and $device-id (alias)
+    and initial $state.
+
+  For a shared-tenancy broker this also writes the device into the
+    auth-side devices table.
   */
-  create-device --device-id/Uuid --state/Map -> none
+  create-device --hardware-id/Uuid --device-id/Uuid --state/Map -> none
 
   /**
   Removes the device with the given $device-id.
@@ -90,7 +95,15 @@ with-broker
     server-config := get-supabase-config --sub-directory=sub-dir
     service-key := get-supabase-service-key --sub-directory=sub-dir
     server-config.poll-interval = Duration --ms=500
-    backdoor := SupabaseBackdoor server-config service-key
+    // The artemis-supabase broker is the toit-hosted, shared-tenancy
+    // deployment that also owns the auth-side devices table; the
+    // public-supabase broker is dedicated.
+    if type == "supabase-local-artemis":
+      server-config = server-config.with --tenancy=TENANCY-SHARED
+    // The backdoor operates inside a fleet's scope (TEST-SCOPE in
+    // tests); the TestBroker's server-config stays scope-less because
+    // it's also reused as a global-config entry.
+    backdoor := SupabaseBackdoor (server-config.with --scope=TEST-SCOPE) service-key
     test-server := TestBroker server-config backdoor
     block.call test-server
   else if type == "http" or type == "http-toit":
@@ -103,7 +116,7 @@ class ToitHttpBackdoor implements BrokerBackdoor:
 
   constructor .server:
 
-  create-device --device-id/Uuid --state/Map:
+  create-device --hardware-id/Uuid --device-id/Uuid --state/Map:
     server.create-device --device-id="$device-id" --state=state
 
   remove-device device-id/Uuid -> none:
@@ -154,8 +167,16 @@ class SupabaseBackdoor implements BrokerBackdoor:
 
   constructor .server-config_ .service-key_:
 
-  create-device --device-id/Uuid --state/Map:
+  create-device --hardware-id/Uuid --device-id/Uuid --state/Map:
     with-backdoor-client_: | client/supabase.Client |
+      if server-config_.tenancy == TENANCY-SHARED:
+        // Shared-tenancy: the broker also owns the auth-side devices
+        // table. Mirror what BrokerCliSupabase does at notify-created.
+        client.rest.insert "devices" --no-return-inserted {
+          "id": "$hardware-id",
+          "alias": "$device-id",
+          "organization_id": server-config_.scope.to-json,
+        }
       client.rest.rpc --schema="toit_artemis" "new_provisioned" {
         "_device_id": "$device-id",
         "_state": state,

--- a/tests/utils.toit
+++ b/tests/utils.toit
@@ -420,9 +420,8 @@ class Tester:
     return result
 
   create-device_ organization-id/Uuid firmware-token/ByteArray?=null -> Map:
-    device-description := artemis.backdoor.create-device --organization-id=organization-id
-    hardware-id/Uuid := device-description["id"]
-    alias-id/Uuid := device-description["alias"]
+    hardware-id := random-uuid
+    alias-id := random-uuid
     initial-state := {
       "identity": {
         "device_id": "$alias-id",
@@ -431,7 +430,10 @@ class Tester:
       }
     }
 
-    broker.backdoor.create-device --device-id=alias-id --state=initial-state
+    broker.backdoor.create-device
+        --hardware-id=hardware-id
+        --device-id=alias-id
+        --state=initial-state
 
     encoded-firmware := build-encoded-firmware
         --firmware-token=firmware-token
@@ -439,9 +441,11 @@ class Tester:
         --organization-id=TEST-ORGANIZATION-UUID
         --hardware-id=hardware-id
 
-    device-description["encoded_firmware"] = encoded-firmware
-
-    return device-description
+    return {
+      "id": hardware-id,
+      "alias": alias-id,
+      "encoded_firmware": encoded-firmware,
+    }
 
   /**
   Stops the main broker.

--- a/tools/http_servers/artemis-server.toit
+++ b/tools/http_servers/artemis-server.toit
@@ -101,8 +101,6 @@ class HttpArtemisServer extends HttpServer:
 
     if command == COMMAND-CHECK-IN_:
       return store-event data
-    if command == COMMAND-CREATE-DEVICE-IN-ORGANIZATION_:
-      return create-device-in-organization data
     if command == COMMAND-SIGN-UP_:
       return sign-up data
     if command == COMMAND-SIGN-IN_:
@@ -140,26 +138,6 @@ class HttpArtemisServer extends HttpServer:
       throw "Device not found"
     events.add
         EventEntry device-id --data=data["data"]
-
-  create-device-in-organization data/Map:
-    organization-id := data["organization_id"]
-    alias := data.get "alias"
-
-    hardware-id := "$(Uuid.uuid5 "" "hardware_id - $Time.monotonic-us")"
-    alias-id := alias or "$(Uuid.uuid5 "" "alias_id - $Time.monotonic-us")"
-
-    devices.do: | key entry/DeviceEntry |
-      if entry.alias == alias-id:
-        throw "Alias already exists"
-
-    devices[hardware-id] = DeviceEntry hardware-id
-        --alias=alias-id
-        --organization-id=organization-id
-    return {
-      "id": hardware-id,
-      "alias": alias-id,
-      "organization_id": organization-id,
-    }
 
   remove-device hardware-id/string -> none:
     devices.remove hardware-id

--- a/tools/http_servers/public/broker/broker.toit
+++ b/tools/http_servers/public/broker/broker.toit
@@ -120,6 +120,8 @@ class HttpBroker extends HttpServer:
   notify-created data/Map:
     device-id := data["_device_id"]
     state := data["_state"]
+    if device-states_.contains device-id:
+      throw "Device $device-id already exists"
     device-states_[device-id] = state
 
   /** Backdoor for creating a new device. */


### PR DESCRIPTION
The auth provider no longer mints device records. Instead, the CLI mints a hardware-id locally and the broker's notify-created is responsible for any further side effects.

Server tenancy:
- ServerConfig grows an optional tenancy/string? field plus constants TENANCY-SHARED and TENANCY-DEDICATED. The field marks whether a server is a multi-tenant deployment that shares its underlying storage with an auth provider (and so must mint auth-side records when registering devices) or a self-contained single-tenant deployment.
- ServerConfigSupabase gains a 'with --tenancy/string' clone to set tenancy without touching other fields.

Broker:
- BrokerCli.notify-created now takes --hardware-id alongside --device-id and --state. Callers mint the hardware-id locally (random-uuid) instead of relying on the auth provider.
- BrokerCliSupabase overrides notify-created: when tenancy is TENANCY-SHARED, it inserts a row into the auth-side 'devices' table (same Supabase project) before delegating to super. Other tenancies skip the cross-table write.

CLI:
- Fleet.provision mints a fresh hardware-id and calls broker.notify-created. The artemis.create-device call is gone.
- The Artemis wrapper no longer exposes create-device.

Deletions:
- AuthProvider.create-device-in-organization (interface + Supabase + HTTP impls).
- COMMAND-CREATE-DEVICE-IN-ORGANIZATION_ constant and its string mapping.
- tools/http_servers/artemis-server.toit handler and the leftover devices state.
- ArtemisServerBackdoor.create-device (test backdoor) and its impls in tests/artemis-server.toit.
- test-create-device-in-organization in tests/auth-provider-test.toit.

Tests:
- BrokerBackdoor.create-device gains --hardware-id; SupabaseBackdoor mirrors the shared-tenancy cross-table insert; ToitHttpBackdoor ignores the new arg.
- tests/broker.toit's with-broker tags the Supabase-artemis test broker with TENANCY-SHARED and attaches TEST-SCOPE to the backdoor's config (the TestBroker's server-config stays scope-less because it doubles as a global-config entry).
- HTTP test broker server (tools/http_servers/public/broker/broker.toit) rejects duplicate notify-created (the auth-side uniqueness check no longer guards it on the CLI's behalf).
- tests/utils.toit's create-device_ mints hardware-id locally and goes through broker.backdoor only.