### PR TITLE
Add HTTP shared-tenancy broker variant for tests.

### DIFF
--- a/src/cli/brokers/broker.toit
+++ b/src/cli/brokers/broker.toit
@@ -28,7 +28,10 @@ interface BrokerCli implements Authenticatable:
     if server-config is ServerConfigSupabase:
       return create-broker-cli-supabase-http (server-config as ServerConfigSupabase) --cli=cli
     if server-config is ServerConfigHttp:
-      return create-broker-cli-http-toit (server-config as ServerConfigHttp)
+      http-config := server-config as ServerConfigHttp
+      if http-config.tenancy == TENANCY-SHARED:
+        return create-broker-cli-http-toit-shared http-config
+      return create-broker-cli-http-toit http-config
     throw "Unknown broker config type"
 
   /** Closes this broker. */

--- a/src/cli/brokers/http/base.toit
+++ b/src/cli/brokers/http/base.toit
@@ -22,6 +22,10 @@ create-broker-cli-http-toit server-config/ServerConfigHttp -> BrokerCliHttp:
   id := "toit-http/$server-config.host-$server-config.port"
   return BrokerCliHttp server-config --id=id
 
+create-broker-cli-http-toit-shared server-config/ServerConfigHttp -> BrokerCliHttpShared:
+  id := "toit-http/$server-config.host-$server-config.port"
+  return BrokerCliHttpShared server-config --id=id
+
 class BrokerCliHttp implements BrokerCli:
   network_/net.Interface? := ?
   id/string
@@ -401,4 +405,24 @@ class BrokerCliHttp implements BrokerCli:
     scope := server-config_.scope.to-json
     return send-request_ COMMAND-DOWNLOAD-PRIVATE_ {
       "path": "/toit-artemis-pods/$scope/manifest/$pod-id",
+    }
+
+/**
+A $BrokerCliHttp specialisation for shared-tenancy HTTP deployments.
+
+In a shared-tenancy deployment the broker also owns the auth-side device
+  record; this override sends the hardware-id and the configured scope
+  (organization-id) so the broker can populate that record alongside the
+  broker-side state.
+*/
+class BrokerCliHttpShared extends BrokerCliHttp:
+  constructor server-config/ServerConfigHttp --id/string:
+    super server-config --id=id
+
+  notify-created --hardware-id/Uuid --device-id/Uuid --state/Map -> none:
+    send-request_ COMMAND-NOTIFY-BROKER-CREATED_ {
+      "_device_id": "$device-id",
+      "_hardware_id": "$hardware-id",
+      "_organization_id": server-config_.scope.to-json,
+      "_state": state,
     }

--- a/src/shared/server-config.toit
+++ b/src/shared/server-config.toit
@@ -387,3 +387,17 @@ class ServerConfigHttp extends ServerConfig:
         --poll-interval=poll-interval
         --scope=scope
         --tenancy=tenancy
+
+  with --tenancy/string -> ServerConfigHttp:
+    return ServerConfigHttp
+        name
+        --host=host
+        --port=port
+        --path=path
+        --use-tls=use-tls
+        --root-certificate-ders=root-certificate-ders
+        --device-headers=device-headers
+        --admin-headers=admin-headers
+        --poll-interval=poll-interval
+        --scope=scope
+        --tenancy=tenancy

--- a/src/shared/server-config.toit
+++ b/src/shared/server-config.toit
@@ -102,12 +102,13 @@ abstract class ServerConfig:
   abstract compute-cache-key_ -> string
 
   /**
-  Returns a copy of this config with $scope set to the given value.
+  Returns a copy of this config with the non-null fields overridden.
 
   Used to attach a fleet's scope to a $ServerConfig that was loaded from
-    the global CLI config (which never carries a scope).
+    the global CLI config (which never carries a scope), or to tag the
+    config with a tenancy mode.
   */
-  abstract with --scope/Scope -> ServerConfig
+  abstract with --scope/Scope?=null --tenancy/string?=null -> ServerConfig
 
   /**
   A unique key that can be used for caching.
@@ -245,38 +246,19 @@ class ServerConfigSupabase extends ServerConfig implements supabase.ServerConfig
   compute-cache-key_ -> string:
     return host
 
-  with --host/string -> ServerConfigSupabase:
+  with -> ServerConfigSupabase
+      --host/string?=null
+      --scope/Scope?=null
+      --tenancy/string?=null:
     return ServerConfigSupabase
         name
-        --host=host
+        --host=(host or this.host)
         --anon=anon
         --use-tls=use-tls
         --root-certificate-der=root-certificate-der
         --poll-interval=poll-interval
-        --scope=scope
-        --tenancy=tenancy
-
-  with --scope/Scope -> ServerConfigSupabase:
-    return ServerConfigSupabase
-        name
-        --host=host
-        --anon=anon
-        --use-tls=use-tls
-        --root-certificate-der=root-certificate-der
-        --poll-interval=poll-interval
-        --scope=scope
-        --tenancy=tenancy
-
-  with --tenancy/string -> ServerConfigSupabase:
-    return ServerConfigSupabase
-        name
-        --host=host
-        --anon=anon
-        --use-tls=use-tls
-        --root-certificate-der=root-certificate-der
-        --poll-interval=poll-interval
-        --scope=scope
-        --tenancy=tenancy
+        --scope=(scope or this.scope)
+        --tenancy=(tenancy or this.tenancy)
 
 /**
 A broker configuration for an HTTP-based broker.
@@ -374,7 +356,9 @@ class ServerConfigHttp extends ServerConfig:
   compute-cache-key_ -> string:
     return "$host:$port:$path"
 
-  with --scope/Scope -> ServerConfigHttp:
+  with -> ServerConfigHttp
+      --scope/Scope?=null
+      --tenancy/string?=null:
     return ServerConfigHttp
         name
         --host=host
@@ -385,19 +369,5 @@ class ServerConfigHttp extends ServerConfig:
         --device-headers=device-headers
         --admin-headers=admin-headers
         --poll-interval=poll-interval
-        --scope=scope
-        --tenancy=tenancy
-
-  with --tenancy/string -> ServerConfigHttp:
-    return ServerConfigHttp
-        name
-        --host=host
-        --port=port
-        --path=path
-        --use-tls=use-tls
-        --root-certificate-ders=root-certificate-ders
-        --device-headers=device-headers
-        --admin-headers=admin-headers
-        --poll-interval=poll-interval
-        --scope=scope
-        --tenancy=tenancy
+        --scope=(scope or this.scope)
+        --tenancy=(tenancy or this.tenancy)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set (SUPABASE_BROKER_FLAG "--supabase-local-broker")
 set (ARTEMIS_FLAGS ${SUPABASE_ARTEMIS_FLAG} "--http-server")
 set (BROKER_FLAGS
       "--http-toit-broker"
+      "--http-toit-shared-broker"
       ${SUPABASE_BROKER_FLAG}
       ${SUPABASE_ARTEMIS_BROKER_FLAG}
     )

--- a/tests/broker-test.toit
+++ b/tests/broker-test.toit
@@ -82,6 +82,15 @@ run-test
       }
       broker-cli.notify-created --hardware-id=device.hardware-id --device-id=device.id --state=state
 
+    if broker-name == "http-toit-shared":
+      // The shared-tenancy HTTP variant must populate the auth-side
+      // device record as part of notify-created.
+      backdoor := test-broker.backdoor as ToitHttpBackdoor
+      [DEVICE1, DEVICE2].do: | device/Device |
+        auth-record := backdoor.get-auth-device --hardware-id=device.hardware-id
+        expect-not-null auth-record
+        expect-equals "$device.id" auth-record["alias"]
+
     network := net.open
     try:
       test-image --test-broker=test-broker broker-cli --network=network

--- a/tests/broker.toit
+++ b/tests/broker.toit
@@ -108,15 +108,25 @@ with-broker
     block.call test-server
   else if type == "http" or type == "http-toit":
     with-http-broker block
+  else if type == "http-toit-shared":
+    with-http-broker --tenancy=TENANCY-SHARED block
   else:
     throw "Unknown broker type: $type"
 
 class ToitHttpBackdoor implements BrokerBackdoor:
   server/HttpBroker
+  server-config_/ServerConfigHttp
 
-  constructor .server:
+  constructor .server .server-config_:
 
   create-device --hardware-id/Uuid --device-id/Uuid --state/Map:
+    if server-config_.tenancy == TENANCY-SHARED:
+      // Shared-tenancy: the broker also owns the auth-side devices
+      // record. Mirror what BrokerCliHttpShared does at notify-created.
+      server.insert-auth-device
+          --hardware-id="$hardware-id"
+          --device-id="$device-id"
+          --organization-id=server-config_.scope.to-json
     server.create-device --device-id="$device-id" --state=state
 
   remove-device device-id/Uuid -> none:
@@ -128,10 +138,13 @@ class ToitHttpBackdoor implements BrokerBackdoor:
   clear-events -> none:
     server.clear-events
 
+  get-auth-device --hardware-id/Uuid -> Map?:
+    return server.get-auth-device --hardware-id="$hardware-id"
+
   stop -> none:
     server.stop
 
-with-http-broker --name="test-broker" [block]:
+with-http-broker --name="test-broker" --tenancy/string?=null [block]:
   server := HttpBroker 0
   port-latch := monitor.Latch
   server-task := task:: server.start port-latch
@@ -151,8 +164,12 @@ with-http-broker --name="test-broker" [block]:
       --device-headers={
         "X-Artemis-Header": "true",
       }
+  if tenancy: server-config = server-config.with --tenancy=tenancy
 
-  backdoor/ToitHttpBackdoor := ToitHttpBackdoor server
+  // The backdoor operates inside a fleet's scope (TEST-SCOPE in
+  // tests); the TestBroker's server-config stays scope-less because
+  // it's also reused as a global-config entry.
+  backdoor/ToitHttpBackdoor := ToitHttpBackdoor server (server-config.with --scope=TEST-SCOPE)
 
   test-server := TestBroker server-config backdoor
   try:

--- a/tools/http_servers/public/broker/broker.toit
+++ b/tools/http_servers/public/broker/broker.toit
@@ -48,6 +48,11 @@ class HttpBroker extends HttpServer:
   device-goals_/Map := {:}
   events_/Map := {:}  // Map from device-id to list of events.
 
+  // Shared-tenancy auth-side device records. Populated when notify-created
+  // includes a hardware-id / organization-id (i.e. the BrokerCliHttpShared
+  // wire shape). Maps hardware-id -> {alias, organization_id}.
+  auth-devices_/Map := {:}
+
   /* Pod description related fields. */
   pod-description-ids_ := 0
   pod-registry_/Map ::= {:}  // Map from pod-description ID to $PodDescription object.
@@ -123,6 +128,24 @@ class HttpBroker extends HttpServer:
     if device-states_.contains device-id:
       throw "Device $device-id already exists"
     device-states_[device-id] = state
+    hardware-id := data.get "_hardware_id"
+    if hardware-id:
+      if auth-devices_.contains hardware-id:
+        throw "Device with hardware-id $hardware-id already exists"
+      auth-devices_[hardware-id] = {
+        "alias": device-id,
+        "organization_id": data.get "_organization_id",
+      }
+
+  get-auth-device --hardware-id/string -> Map?:
+    return auth-devices_.get hardware-id
+
+  /** Backdoor for inserting an auth-side device record. */
+  insert-auth-device --hardware-id/string --device-id/string --organization-id/any:
+    auth-devices_[hardware-id] = {
+      "alias": device-id,
+      "organization_id": organization-id,
+    }
 
   /** Backdoor for creating a new device. */
   create-device --device-id/string --state/Map:


### PR DESCRIPTION
Mirrors the BrokerCliSupabase shared-tenancy path so the HTTP test broker can exercise the cross-table auth-side write that production shared-tenancy deployments rely on.

CLI:
- BrokerCliHttpShared (subclass of BrokerCliHttp) overrides notify-created to send _hardware_id and _organization_id alongside _device_id/_state on the wire.
- BrokerCli factory dispatches HTTP + TENANCY-SHARED to the shared variant; other HTTP configs keep the dedicated path.

Shared config:
- ServerConfigHttp gains a 'with --tenancy/string' clone, matching the Supabase variant.

HTTP test broker server:
- Stores auth-side device records in auth-devices_ when notify-created carries the extra fields. Rejects duplicate hardware-ids.
- Exposes get-auth-device + insert-auth-device for the backdoor.

Tests:
- with-broker recognizes 'http-toit-shared'; with-http-broker takes an optional --tenancy to opt into shared mode.
- ToitHttpBackdoor carries the scoped ServerConfigHttp and mirrors the shared-tenancy auth-side insert in its create-device backdoor.
- broker-test.toit asserts auth-side records are populated when running under http-toit-shared.
- CMakeLists.txt adds --http-toit-shared-broker to BROKER_FLAGS so all BROKER tests exercise the shared HTTP variant.