### PR TITLE
Fix Map.contains-key regression; update SDK matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ env:
       v2.0.0-alpha.186
       v2.0.0-alpha.189
       v2.0.0-alpha.190
+      v2.0.0-alpha.191
+      v2.0.0-alpha.192
+      v2.0.0-alpha.193
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,16 +26,12 @@ on:
 
 env:
   SUPPORTED_SDK_VERSIONS: |
-      v2.0.0-alpha.176
-      v2.0.0-alpha.180
-      v2.0.0-alpha.182
-      v2.0.0-alpha.184
-      v2.0.0-alpha.186
       v2.0.0-alpha.189
       v2.0.0-alpha.190
       v2.0.0-alpha.191
       v2.0.0-alpha.192
       v2.0.0-alpha.193
+      v2.0.0-alpha.194
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ on:
 
 env:
   SUPPORTED_SDK_VERSIONS: |
+      v2.0.0-alpha.176
+      v2.0.0-alpha.180
+      v2.0.0-alpha.182
+      v2.0.0-alpha.184
+      v2.0.0-alpha.186
       v2.0.0-alpha.189
       v2.0.0-alpha.190
       v2.0.0-alpha.191

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 TOIT ?= toit$(EXE_SUFFIX)
 
-LOCAL_DEV_SDK ?= v2.0.0-alpha.193
+LOCAL_DEV_SDK ?= v2.0.0-alpha.194
 SETUP_LOCAL_DEV_SERVICE ?= v0.0.1
 
 SUPABASE_DIRS := supabase_artemis public/supabase_broker

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 TOIT ?= toit$(EXE_SUFFIX)
 
-LOCAL_DEV_SDK ?= v2.0.0-alpha.190
+LOCAL_DEV_SDK ?= v2.0.0-alpha.193
 SETUP_LOCAL_DEV_SERVICE ?= v0.0.1
 
 SUPABASE_DIRS := supabase_artemis public/supabase_broker

--- a/src/service/network.toit
+++ b/src/service/network.toit
@@ -205,7 +205,7 @@ class ConnectionCellular extends Connection:
     // if things have changed since last attempt.
     cellular.reset
     config := description_.get "config" --if-absent=: {:}
-    if config.contains-key "log.level":
+    if config.contains "log.level":
       config-level := config["log.level"]
       level := config-level
       if level is string:


### PR DESCRIPTION
## Summary

- **Fix `Map.contains-key` typo** in [src/service/network.toit:208](src/service/network.toit#L208) — introduced in #1210 ("Support TRACE level logging"), shipped in v0.32.0, v0.33.0, v0.34.0. `Map.contains-key` has never existed on Toit's `Map`; the correct method is `Map.contains`. The lookup failure happens at method dispatch, **not** at the test, so the line throws `LOOKUP_FAILED` for **every cellular pod** on these versions — independent of whether `log.level` is in the config. Wifi/Ethernet are unaffected (single call site in artemis source). The swallowing `catch:` in network.toit:104 buries it as `opening failed {error: LOOKUP_FAILED}` in the network log.
- **Add alpha.194 to the supported SDK matrix.** All previously-supported SDKs (.176–.193) are kept so the v0.34.0 republish covers every (SDK × v0.34.0) row in `sdk_service_versions` — cellular is equally broken on every SDK pairing.

This branch is squash-mergeable: there are four commits because the SDK matrix was first narrowed, then re-expanded after realizing the bug fires for every cellular user. End state is identical to "add .194 + fix typo".

## Severity

All cellular users on Artemis service v0.32.0, v0.33.0, or v0.34.0 are affected — every cellular pod throws `LOOKUP_FAILED` at boot regardless of config contents. Initial hypothesis that the bug was conditional on `cellular.log.level` being set was wrong; the missing method is dispatched even when the key isn't present (verified on cellular-04: removing the key didn't help).

## Test plan
- [x] Diagnosed end-to-end on cellular-04 with a `catch --trace:` patched service; trace pinpoints network.toit:208 calling `Map.contains-key`.
- [x] Confirmed workaround (removing `cellular.log.level`) does **not** help — the lookup still fails. No service-side workaround exists.
- [ ] After merge: cut a v0.34.0 GitHub release so the workflow force-uploads the fixed binary across the full SDK matrix. Consider also republishing v0.32.0 / v0.33.0 (cellular users on those versions are equally broken).